### PR TITLE
[Fix] improve Telegram command health status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ src/
 │   │   ├── handlers/
 │   │   │   ├── telegram-handlers.ts    Registers all bot listeners
 │   │   │   ├── message-handlers.ts     Per-type message handling
-│   │   │   └── command-handlers.ts     /start /help /status (BROKEN — not registered)
+│   │   │   └── command-handlers.ts     /help /status + operational health output
 │   │   └── processors/
 │   │       ├── text-processor.service.ts
 │   │       └── audio-processor.service.ts
@@ -124,11 +124,10 @@ src/
 
 ## Known Issues (Fix Before Adding Features)
 
-1. **Bot commands are broken** — `command-handlers.ts` is written but never registered in `telegram-handlers.ts`. `/start`, `/help`, `/status` do nothing.
-2. **Retry logic is disconnected** — `gpt-error-handler.service.ts` has `isRetryableError()` and `getRetryDelay()` but they're never called.
-3. **No env var validation at startup** — missing keys crash deep inside services.
-4. **`AUDIO_MIME_TYPES` defined twice** — `file.service.ts` should import from `utils/constants.ts`.
-5. **Empty stubs** — `server.ts`, `guardrail.service.ts`, `mcp-service.ts` are 1-line files with no intent documented.
+1. **Retry logic is disconnected** — `gpt-error-handler.service.ts` has `isRetryableError()` and `getRetryDelay()` but they're never called.
+2. **No env var validation at startup** — missing keys crash deep inside services.
+3. **`AUDIO_MIME_TYPES` defined twice** — `file.service.ts` should import from `utils/constants.ts`.
+4. **Empty stubs** — `server.ts`, `guardrail.service.ts`, `mcp-service.ts` are 1-line files with no intent documented.
 
 Full details in `reports/BUGS_AND_BROKEN.md`.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ RUN_INTEGRATION_TESTS=true
 
 ### Method 2: Using Your Own Bot
 1. Start your bot (see Step 4 below)
-2. Send `/start` to your bot
+2. Send `/help` to your bot
 3. Check the console logs - your user ID will be logged
 4. Copy the `userId` from the logs to your `.env` file
 
@@ -96,8 +96,8 @@ npx ts-node src/app.ts
 
 ### Manual Testing
 1. Find your bot on Telegram (using the username from @BotFather)
-2. Send `/start` - should get welcome message
-3. Send `/help` - should get help text
+2. Send `/help` - should get help text and supported command list
+3. Send `/status` - should get runtime, GPT, Todoist, and activity status
 4. Send any text message - should echo it back
 5. Send an audio file - should process it
 
@@ -129,7 +129,7 @@ Telegram → Webhook → ngrok → Your Server → Bot Service → Response → 
 - ✅ Text message echoing
 - ✅ Audio file detection and info display
 - ✅ Voice message handling
-- ✅ Command handling (/start, /help, /status)
+- ✅ Command handling (/help, /status)
 
 ### Potential Next Features:
 - 🔄 **Audio Processing**: Implement actual audio transcription/analysis

--- a/reports/PROJECT_STATUS.md
+++ b/reports/PROJECT_STATUS.md
@@ -35,7 +35,7 @@ The architecture is clean and well-thought-out. The main processing pipeline (Te
 | GPT text processing | Done |
 | GPT function calling | Done |
 | Todoist REST API integration | Done |
-| Bot command handlers (/start, /help, /status) | Defined but broken — never registered |
+| Bot command handlers (/help, /status) | Working |
 | Guardrail / content filtering | Empty stub |
 | MCP server infrastructure | Built but unused |
 | Test suite | Empty |
@@ -97,7 +97,7 @@ NODE_ENV               - development | production
 | `src/services/ai/whisper.service.ts` | Audio transcription | Working |
 | `src/services/external/todoist-api.service.ts` | Todoist REST client | Working |
 | `src/services/mcp/direct-tool-dispatcher.service.ts` | Function call routing | Working |
-| `src/services/telegram/handlers/command-handlers.ts` | /start /help /status | Broken |
+| `src/services/telegram/handlers/command-handlers.ts` | /help /status | Working |
 | `src/services/ai/guardrail.service.ts` | Content filtering | Empty stub |
 | `src/server.ts` | Unused server file | Empty stub |
 | `src/services/mcp/mcp-service.ts` | MCP service | Empty stub |

--- a/reports/TODO_AND_INCOMPLETE.md
+++ b/reports/TODO_AND_INCOMPLETE.md
@@ -55,13 +55,18 @@ This becomes much cleaner once the LangGraph pipeline exists — memory retrieva
 
 ---
 
-### 5. Better /status command
+### 5. Expand /status further if needed
 
-Current reply: `"Bot is running and ready"`. Should include:
+Current `/status` now includes:
 - Uptime
 - GPT model in use
-- Whether Todoist API is reachable (live ping)
-- Message count or last active time
+- Whether Todoist API is reachable
+- Message count and last active time
+
+Possible follow-ups:
+- Add webhook vs polling mode
+- Include recent error count
+- Include OpenAI connectivity checks
 
 ---
 

--- a/src/services/external/todoist-api.service.ts
+++ b/src/services/external/todoist-api.service.ts
@@ -307,6 +307,21 @@ export class TodoistAPIService {
     return projects;
   }
 
+  async checkHealth(): Promise<{ ok: boolean; detail: string }> {
+    try {
+      const projects = await this.getProjects();
+      return {
+        ok: true,
+        detail: `${projects.length} project(s) visible`,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        detail: (error as Error).message,
+      };
+    }
+  }
+
   /**
    * Get completed tasks (Note: This requires Todoist Premium)
    * Uses the Sync API for retrieving completed tasks

--- a/src/services/telegram/bot-activity.service.ts
+++ b/src/services/telegram/bot-activity.service.ts
@@ -1,0 +1,42 @@
+export type BotActivityType =
+  | 'command_help'
+  | 'command_status'
+  | 'message_text'
+  | 'message_voice'
+  | 'message_audio'
+  | 'message_document'
+  | 'message_unknown';
+
+export interface BotActivitySnapshot {
+  startedAt: Date;
+  uptimeMs: number;
+  totalInteractions: number;
+  lastActivityAt: Date | null;
+  lastActivityType: BotActivityType | null;
+}
+
+/**
+ * Tracks lightweight in-process bot activity for operational status reporting.
+ */
+export class BotActivityService {
+  private readonly startedAt = new Date();
+  private totalInteractions = 0;
+  private lastActivityAt: Date | null = null;
+  private lastActivityType: BotActivityType | null = null;
+
+  recordActivity(type: BotActivityType): void {
+    this.totalInteractions += 1;
+    this.lastActivityAt = new Date();
+    this.lastActivityType = type;
+  }
+
+  getSnapshot(): BotActivitySnapshot {
+    return {
+      startedAt: this.startedAt,
+      uptimeMs: Date.now() - this.startedAt.getTime(),
+      totalInteractions: this.totalInteractions,
+      lastActivityAt: this.lastActivityAt,
+      lastActivityType: this.lastActivityType,
+    };
+  }
+}

--- a/src/services/telegram/bot-status.service.ts
+++ b/src/services/telegram/bot-status.service.ts
@@ -1,0 +1,143 @@
+import { GPT_CONSTANTS } from '../ai/constants/gpt.constants';
+import { TodoistAPIService } from '../external/todoist-api.service';
+import { BotActivityService } from './bot-activity.service';
+
+export interface BotStatusServiceOptions {
+  gptModel?: string;
+  todoistService?: Pick<TodoistAPIService, 'getProjects'>;
+}
+
+export interface BotStatusSnapshot {
+  runtime: {
+    ok: boolean;
+    uptimeMs: number;
+    startedAt: Date;
+  };
+  gpt: {
+    model: string;
+  };
+  todoist: {
+    ok: boolean;
+    detail: string;
+  };
+  activity: {
+    totalInteractions: number;
+    lastActivityAt: Date | null;
+    lastActivityType: string | null;
+  };
+}
+
+/**
+ * Aggregates runtime health for the Telegram /status command.
+ */
+export class BotStatusService {
+  private readonly gptModel: string;
+  private readonly todoistService?: Pick<TodoistAPIService, 'getProjects'>;
+
+  constructor(
+    private readonly activityService: BotActivityService,
+    options: BotStatusServiceOptions = {},
+  ) {
+    this.gptModel = options.gptModel || GPT_CONSTANTS.DEFAULT_MODEL;
+    this.todoistService = options.todoistService;
+  }
+
+  async getSnapshot(): Promise<BotStatusSnapshot> {
+    const activity = this.activityService.getSnapshot();
+    const todoist = await this.getTodoistStatus();
+
+    return {
+      runtime: {
+        ok: true,
+        uptimeMs: activity.uptimeMs,
+        startedAt: activity.startedAt,
+      },
+      gpt: {
+        model: this.gptModel,
+      },
+      todoist,
+      activity: {
+        totalInteractions: activity.totalInteractions,
+        lastActivityAt: activity.lastActivityAt,
+        lastActivityType: activity.lastActivityType,
+      },
+    };
+  }
+
+  async getFormattedStatus(): Promise<string> {
+    const snapshot = await this.getSnapshot();
+    const overallStatus = snapshot.todoist.ok ? 'healthy' : 'degraded';
+
+    return [
+      `🤖 *Jarvis Status: ${overallStatus.toUpperCase()}*`,
+      '',
+      `*Runtime*`,
+      `• Bot: ${snapshot.runtime.ok ? 'online' : 'offline'}`,
+      `• Uptime: ${this.formatDuration(snapshot.runtime.uptimeMs)}`,
+      `• Started: ${snapshot.runtime.startedAt.toISOString()}`,
+      '',
+      `*AI*`,
+      `• GPT model: ${snapshot.gpt.model}`,
+      '',
+      `*Dependencies*`,
+      `• Todoist: ${snapshot.todoist.ok ? 'reachable' : 'degraded'} (${snapshot.todoist.detail})`,
+      '',
+      `*Recent Activity*`,
+      `• Total interactions: ${snapshot.activity.totalInteractions}`,
+      `• Last activity: ${this.formatLastActivity(snapshot.activity.lastActivityAt)}`,
+      `• Last activity type: ${snapshot.activity.lastActivityType || 'none yet'}`,
+    ].join('\n');
+  }
+
+  private async getTodoistStatus(): Promise<BotStatusSnapshot['todoist']> {
+    if (!this.todoistService) {
+      return {
+        ok: false,
+        detail: 'not configured',
+      };
+    }
+
+    try {
+      const projects = await this.todoistService.getProjects();
+      return {
+        ok: true,
+        detail: `${projects.length} project(s) visible`,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        detail: (error as Error).message,
+      };
+    }
+  }
+
+  private formatDuration(durationMs: number): string {
+    const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }
+
+  private formatLastActivity(lastActivityAt: Date | null): string {
+    if (!lastActivityAt) {
+      return 'none yet';
+    }
+
+    const elapsedMs = Date.now() - lastActivityAt.getTime();
+    const elapsedSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+
+    if (elapsedSeconds < 60) {
+      return `${elapsedSeconds}s ago`;
+    }
+
+    const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+    if (elapsedMinutes < 60) {
+      return `${elapsedMinutes}m ago`;
+    }
+
+    const elapsedHours = Math.floor(elapsedMinutes / 60);
+    return `${elapsedHours}h ago`;
+  }
+}

--- a/src/services/telegram/handlers/command-handlers.ts
+++ b/src/services/telegram/handlers/command-handlers.ts
@@ -1,36 +1,33 @@
 // src/services/telegram/handlers/command-handlers.ts
 import { Context } from 'telegraf';
 import { logger } from '../../../utils/logger';
+import { BotActivityService } from '../bot-activity.service';
+import { BotStatusService } from '../bot-status.service';
 
 /**
  * Handles bot commands
  */
 export class CommandHandlers {
-  async handleStart(ctx: Context): Promise<void> {
-    const userId = ctx.from?.id;
-    const username = ctx.from?.username;
-
-    logger.info('User started bot', { userId, username });
-
-    const name = ctx.from?.first_name ?? 'there';
-    await ctx.reply(`Hey ${name}! I'm Jarvis, your personal assistant. Send me a message or try /help.`);
-  }
+  constructor(
+    private readonly activityService: BotActivityService,
+    private readonly statusService: BotStatusService,
+  ) {}
 
   async handleHelp(ctx: Context): Promise<void> {
     const userId = ctx.from?.id;
     logger.info('User requested help', { userId });
+    this.activityService.recordActivity('command_help');
 
     const helpMessage = `🆘 *JarvisMCP Help*
 
 *Available Commands:*
-/start - Start the bot
 /help - Show this help message
 /status - Check bot status
 
 *Features:*
-📝 Send me any text message and I'll process it
-🎵 Send me audio files (.ogg, .mp3, .wav) and I'll process them
-🔊 Send me voice messages and I'll handle them
+📝 Send any text message and I'll process it
+🎵 Send audio files (.ogg, .mp3, .wav, .m4a) and I'll process them
+🔊 Send voice messages and I'll handle them right away
 
 *Supported Audio Formats:*
 • OGG Vorbis (Telegram voice messages)
@@ -44,7 +41,9 @@ export class CommandHandlers {
   async handleStatus(ctx: Context): Promise<void> {
     const userId = ctx.from?.id;
     logger.info('User requested status', { userId });
+    this.activityService.recordActivity('command_status');
 
-    await ctx.reply('✅ Bot is running and ready to process your messages!');
+    const statusMessage = await this.statusService.getFormattedStatus();
+    await ctx.reply(statusMessage, { parse_mode: 'Markdown' });
   }
 }

--- a/src/services/telegram/handlers/message-handlers.ts
+++ b/src/services/telegram/handlers/message-handlers.ts
@@ -3,6 +3,7 @@ import { Context } from 'telegraf';
 import { logger } from '../../../utils/logger';
 import { FileService } from '../file.service';
 import { MessageProcessorService } from '../message-processor.service';
+import { BotActivityService } from '../bot-activity.service';
 
 /**
  * Handles different types of messages
@@ -10,7 +11,8 @@ import { MessageProcessorService } from '../message-processor.service';
 export class MessageHandlers {
   constructor(
     private readonly fileService: FileService,
-    private readonly messageProcessor: MessageProcessorService
+    private readonly messageProcessor: MessageProcessorService,
+    private readonly activityService: BotActivityService,
   ) {}
 
   async handleText(ctx: Context): Promise<void> {
@@ -24,6 +26,7 @@ export class MessageHandlers {
       username: ctx.from?.username,
       messageLength: messageText.length
     });
+    this.activityService.recordActivity('message_text');
 
     try {
       const response = await this.messageProcessor.processTextMessage(messageText, userId);
@@ -48,6 +51,7 @@ export class MessageHandlers {
       duration: voice.duration,
       fileSize: voice.file_size
     });
+    this.activityService.recordActivity('message_voice');
 
     try {
       const fileUrl = await this.fileService.getFileUrl(voice.file_id);
@@ -66,6 +70,7 @@ export class MessageHandlers {
     if (!ctx.message || !('audio' in ctx.message)) return;
 
     const audio = ctx.message.audio;
+    this.activityService.recordActivity('message_audio');
     await this.processAudioFile(ctx, audio);
   }
 
@@ -76,6 +81,7 @@ export class MessageHandlers {
     const userId = ctx.from?.id;
 
     if (this.fileService.isAudioFile(document.mime_type)) {
+      this.activityService.recordActivity('message_document');
       const fileName = document.file_name || 'audio_file';
       const mimeType = document.mime_type || 'application/octet-stream';
 
@@ -120,6 +126,7 @@ export class MessageHandlers {
       userId,
       messageType: 'unknown'
     });
+    this.activityService.recordActivity('message_unknown');
 
     await ctx.reply(
       '🤔 I received your message, but I don\'t know how to handle this type yet. Try sending text or audio!'

--- a/src/services/telegram/handlers/telegram-handlers.ts
+++ b/src/services/telegram/handlers/telegram-handlers.ts
@@ -4,6 +4,8 @@ import { FileService } from '../file.service';
 import { MessageProcessorService } from '../message-processor.service';
 import { CommandHandlers } from '../handlers/command-handlers';
 import { MessageHandlers } from '../handlers/message-handlers';
+import { BotActivityService } from '../bot-activity.service';
+import { BotStatusService } from '../bot-status.service';
 
 /**
  * Centralizes all Telegram bot handlers
@@ -12,9 +14,14 @@ export class TelegramHandlers {
   private readonly commandHandlers: CommandHandlers;
   private readonly messageHandlers: MessageHandlers;
 
-  constructor(fileService: FileService, messageProcessor: MessageProcessorService) {
-    this.commandHandlers = new CommandHandlers();
-    this.messageHandlers = new MessageHandlers(fileService, messageProcessor);
+  constructor(
+    fileService: FileService,
+    messageProcessor: MessageProcessorService,
+    activityService: BotActivityService,
+    statusService: BotStatusService,
+  ) {
+    this.commandHandlers = new CommandHandlers(activityService, statusService);
+    this.messageHandlers = new MessageHandlers(fileService, messageProcessor, activityService);
   }
 
   setupHandlers(bot: Telegraf<Context>): void {
@@ -23,7 +30,6 @@ export class TelegramHandlers {
   }
 
   private setupCommandHandlers(bot: Telegraf<Context>): void {
-    bot.command('start', this.commandHandlers.handleStart.bind(this.commandHandlers));
     bot.command('help', this.commandHandlers.handleHelp.bind(this.commandHandlers));
     bot.command('status', this.commandHandlers.handleStatus.bind(this.commandHandlers));
   }

--- a/src/services/telegram/telegram-bot.service.ts
+++ b/src/services/telegram/telegram-bot.service.ts
@@ -6,6 +6,10 @@ import { TelegramHandlers } from './handlers/telegram-handlers';
 import { FileService } from './file.service';
 import { MessageProcessorService } from './message-processor.service';
 import { TelegramConfig } from '../../types/telegram.types';
+import { BotActivityService } from './bot-activity.service';
+import { BotStatusService } from './bot-status.service';
+import { TodoistAPIService } from '../external/todoist-api.service';
+import { GPT_CONSTANTS } from '../ai/constants/gpt.constants';
 
 /**
  * Service class responsible for managing Telegram bot operations
@@ -16,6 +20,8 @@ export class TelegramBotService {
   private readonly handlers: TelegramHandlers;
   private readonly fileService: FileService;
   private readonly messageProcessor: MessageProcessorService;
+  private readonly activityService: BotActivityService;
+  private readonly statusService: BotStatusService;
 
   constructor(
     config: TelegramConfig,
@@ -25,7 +31,19 @@ export class TelegramBotService {
     this.bot = new Telegraf(config.token);
     this.messageProcessor = messageProcessor;
     this.fileService = new FileService(this.botToken, this.bot.telegram);
-    this.handlers = new TelegramHandlers(this.fileService, this.messageProcessor);
+    this.activityService = new BotActivityService();
+    this.statusService = new BotStatusService(this.activityService, {
+      gptModel: process.env.OPENAI_MODEL || GPT_CONSTANTS.DEFAULT_MODEL,
+      todoistService: process.env.TODOIST_API_KEY
+        ? new TodoistAPIService(process.env.TODOIST_API_KEY)
+        : undefined,
+    });
+    this.handlers = new TelegramHandlers(
+      this.fileService,
+      this.messageProcessor,
+      this.activityService,
+      this.statusService,
+    );
 
     this.setupBotHandlers();
     this.setupErrorHandling();
@@ -72,6 +90,8 @@ export class TelegramBotService {
       const fullWebhookUrl = `${webhookUrl}/webhook/${secretToken}`;
 
       logger.info('Setting up webhook', { url: fullWebhookUrl });
+
+      await this.syncCommands();
 
       await this.bot.telegram.setWebhook(fullWebhookUrl, {
         secret_token: secretToken,
@@ -160,6 +180,7 @@ export class TelegramBotService {
    */
   async startPolling(): Promise<void> {
     try {
+      await this.syncCommands();
       await this.bot.launch();
       logger.info('Bot started polling for updates');
     } catch (error) {
@@ -182,5 +203,12 @@ export class TelegramBotService {
         error: (error as Error).message
       });
     }
+  }
+
+  private async syncCommands(): Promise<void> {
+    await this.bot.telegram.setMyCommands([
+      { command: 'help', description: 'Show available commands and supported inputs' },
+      { command: 'status', description: 'Show bot health, uptime, and dependency status' },
+    ]);
   }
 }

--- a/tests/unit/services/telegram/bot-status.service.test.ts
+++ b/tests/unit/services/telegram/bot-status.service.test.ts
@@ -1,0 +1,40 @@
+import { BotActivityService } from '../../../../src/services/telegram/bot-activity.service';
+import { BotStatusService } from '../../../../src/services/telegram/bot-status.service';
+
+describe('BotStatusService', () => {
+  it('reports a healthy runtime when Todoist is reachable', async () => {
+    const activity = new BotActivityService();
+    activity.recordActivity('message_text');
+
+    const service = new BotStatusService(activity, {
+      gptModel: 'gpt-4o',
+      todoistService: {
+        getProjects: jest.fn().mockResolvedValue([{ id: '1' }]),
+      } as any,
+    });
+
+    const status = await service.getFormattedStatus();
+
+    expect(status).toContain('HEALTHY');
+    expect(status).toContain('GPT model: gpt-4o');
+    expect(status).toContain('Todoist: reachable');
+    expect(status).toContain('Total interactions: 1');
+    expect(status).toContain('Last activity type: message_text');
+  });
+
+  it('reports degraded dependency health when Todoist check fails', async () => {
+    const activity = new BotActivityService();
+    const service = new BotStatusService(activity, {
+      todoistService: {
+        getProjects: jest.fn().mockRejectedValue(new Error('Todoist API error (401): unauthorized')),
+      } as any,
+    });
+
+    const status = await service.getFormattedStatus();
+
+    expect(status).toContain('DEGRADED');
+    expect(status).toContain('Todoist: degraded');
+    expect(status).toContain('unauthorized');
+    expect(status).toContain('Last activity: none yet');
+  });
+});

--- a/tests/unit/services/telegram/handlers/command-handlers.test.ts
+++ b/tests/unit/services/telegram/handlers/command-handlers.test.ts
@@ -1,0 +1,66 @@
+import { CommandHandlers } from '../../../../../src/services/telegram/handlers/command-handlers';
+
+describe('CommandHandlers', () => {
+  function createContext() {
+    return {
+      from: { id: 123, username: 'tester' },
+      reply: jest.fn().mockResolvedValue(undefined),
+    } as any;
+  }
+
+  function createActivityService() {
+    return {
+      recordActivity: jest.fn(),
+    } as any;
+  }
+
+  it('returns help text that only advertises /help and /status', async () => {
+    const ctx = createContext();
+    const activityService = createActivityService();
+    const statusService = {
+      getFormattedStatus: jest.fn(),
+    } as any;
+    const handlers = new CommandHandlers(activityService, statusService);
+
+    await handlers.handleHelp(ctx);
+
+    expect(activityService.recordActivity).toHaveBeenCalledWith('command_help');
+    expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining('/help'), {
+      parse_mode: 'Markdown',
+    });
+    expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining('/status'), {
+      parse_mode: 'Markdown',
+    });
+    expect(ctx.reply).toHaveBeenCalledWith(expect.not.stringContaining('/start'), {
+      parse_mode: 'Markdown',
+    });
+  });
+
+  it('returns a formatted healthy status response', async () => {
+    const ctx = createContext();
+    const activityService = createActivityService();
+    const statusService = {
+      getFormattedStatus: jest.fn().mockResolvedValue('healthy status'),
+    } as any;
+    const handlers = new CommandHandlers(activityService, statusService);
+
+    await handlers.handleStatus(ctx);
+
+    expect(activityService.recordActivity).toHaveBeenCalledWith('command_status');
+    expect(statusService.getFormattedStatus).toHaveBeenCalled();
+    expect(ctx.reply).toHaveBeenCalledWith('healthy status', { parse_mode: 'Markdown' });
+  });
+
+  it('returns a formatted degraded status response without throwing', async () => {
+    const ctx = createContext();
+    const activityService = createActivityService();
+    const statusService = {
+      getFormattedStatus: jest.fn().mockResolvedValue('degraded status'),
+    } as any;
+    const handlers = new CommandHandlers(activityService, statusService);
+
+    await handlers.handleStatus(ctx);
+
+    expect(ctx.reply).toHaveBeenCalledWith('degraded status', { parse_mode: 'Markdown' });
+  });
+});

--- a/tests/unit/services/telegram/handlers/message-handlers.test.ts
+++ b/tests/unit/services/telegram/handlers/message-handlers.test.ts
@@ -18,7 +18,10 @@ describe('MessageHandlers', () => {
       processAudioDocument: jest.fn().mockResolvedValue('processed document'),
       processAudioMessage: jest.fn(),
     } as any;
-    const handlers = new MessageHandlers(fileService, messageProcessor);
+    const activityService = {
+      recordActivity: jest.fn(),
+    } as any;
+    const handlers = new MessageHandlers(fileService, messageProcessor, activityService);
     const ctx = createContext({
       document: {
         file_id: 'file-1',
@@ -39,6 +42,7 @@ describe('MessageHandlers', () => {
       123,
     );
     expect(messageProcessor.processAudioMessage).not.toHaveBeenCalled();
+    expect(activityService.recordActivity).toHaveBeenCalledWith('message_document');
     expect(ctx.reply).toHaveBeenCalledWith('processed document');
   });
 
@@ -50,7 +54,10 @@ describe('MessageHandlers', () => {
     const messageProcessor = {
       processAudioDocument: jest.fn(),
     } as any;
-    const handlers = new MessageHandlers(fileService, messageProcessor);
+    const activityService = {
+      recordActivity: jest.fn(),
+    } as any;
+    const handlers = new MessageHandlers(fileService, messageProcessor, activityService);
     const ctx = createContext({
       document: {
         file_id: 'file-1',
@@ -63,6 +70,7 @@ describe('MessageHandlers', () => {
 
     expect(fileService.getFileUrl).not.toHaveBeenCalled();
     expect(messageProcessor.processAudioDocument).not.toHaveBeenCalled();
+    expect(activityService.recordActivity).not.toHaveBeenCalled();
     expect(ctx.reply).toHaveBeenCalledWith(
       '📄 I received a document, but I only process audio files. Please send an audio file.',
     );
@@ -76,7 +84,10 @@ describe('MessageHandlers', () => {
     const messageProcessor = {
       processAudioDocument: jest.fn(),
     } as any;
-    const handlers = new MessageHandlers(fileService, messageProcessor);
+    const activityService = {
+      recordActivity: jest.fn(),
+    } as any;
+    const handlers = new MessageHandlers(fileService, messageProcessor, activityService);
     const ctx = createContext({
       document: {
         file_id: 'file-1',
@@ -90,5 +101,6 @@ describe('MessageHandlers', () => {
     expect(ctx.reply).toHaveBeenCalledWith(
       '❌ Sorry, I had trouble processing your audio document.',
     );
+    expect(activityService.recordActivity).toHaveBeenCalledWith('message_document');
   });
 });

--- a/tests/unit/services/telegram/handlers/telegram-handlers.test.ts
+++ b/tests/unit/services/telegram/handlers/telegram-handlers.test.ts
@@ -1,0 +1,31 @@
+import { TelegramHandlers } from '../../../../../src/services/telegram/handlers/telegram-handlers';
+
+describe('TelegramHandlers', () => {
+  it('registers only /help and /status commands', () => {
+    const bot = {
+      command: jest.fn(),
+      on: jest.fn(),
+    } as any;
+    const fileService = {} as any;
+    const messageProcessor = {} as any;
+    const activityService = {
+      recordActivity: jest.fn(),
+    } as any;
+    const statusService = {
+      getFormattedStatus: jest.fn(),
+    } as any;
+    const handlers = new TelegramHandlers(
+      fileService,
+      messageProcessor,
+      activityService,
+      statusService,
+    );
+
+    handlers.setupHandlers(bot);
+
+    expect(bot.command).toHaveBeenCalledTimes(2);
+    expect(bot.command).toHaveBeenNthCalledWith(1, 'help', expect.any(Function));
+    expect(bot.command).toHaveBeenNthCalledWith(2, 'status', expect.any(Function));
+    expect(bot.command).not.toHaveBeenCalledWith('start', expect.any(Function));
+  });
+});

--- a/tests/unit/services/telegram/telegram-bot.service.test.ts
+++ b/tests/unit/services/telegram/telegram-bot.service.test.ts
@@ -1,0 +1,88 @@
+jest.mock('telegraf', () => {
+  class MockTelegraf {
+    public telegram = {
+      setWebhook: jest.fn().mockResolvedValue(undefined),
+      deleteWebhook: jest.fn().mockResolvedValue(undefined),
+      sendMessage: jest.fn().mockResolvedValue({}),
+      getMe: jest.fn().mockResolvedValue({}),
+      setMyCommands: jest.fn().mockResolvedValue(undefined),
+    };
+    public command = jest.fn();
+    public on = jest.fn();
+    public catch = jest.fn();
+    public handleUpdate = jest.fn().mockResolvedValue(undefined);
+    public launch = jest.fn().mockResolvedValue(undefined);
+    public stop = jest.fn();
+
+    constructor(public readonly token: string) {}
+  }
+
+  return {
+    Telegraf: MockTelegraf,
+  };
+});
+
+describe('TelegramBotService', () => {
+  const originalTodoistApiKey = process.env.TODOIST_API_KEY;
+  const originalOpenAiModel = process.env.OPENAI_MODEL;
+
+  beforeEach(() => {
+    process.env.TODOIST_API_KEY = 'todoist-key';
+    process.env.OPENAI_MODEL = 'gpt-4o';
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+
+    if (originalTodoistApiKey === undefined) {
+      delete process.env.TODOIST_API_KEY;
+    } else {
+      process.env.TODOIST_API_KEY = originalTodoistApiKey;
+    }
+
+    if (originalOpenAiModel === undefined) {
+      delete process.env.OPENAI_MODEL;
+    } else {
+      process.env.OPENAI_MODEL = originalOpenAiModel;
+    }
+  });
+
+  async function createService() {
+    const { TelegramBotService } = await import('../../../../src/services/telegram/telegram-bot.service');
+    return new TelegramBotService(
+      {
+        token: 'bot-token',
+        webhookUrl: 'https://example.com',
+        secretToken: 'secret',
+      },
+      {} as any,
+    );
+  }
+
+  it('syncs only /help and /status before webhook setup', async () => {
+    const service = await createService();
+
+    await service.setupWebhook('https://example.com', 'secret');
+
+    expect(service.bot.telegram.setMyCommands).toHaveBeenCalledWith([
+      { command: 'help', description: 'Show available commands and supported inputs' },
+      { command: 'status', description: 'Show bot health, uptime, and dependency status' },
+    ]);
+    expect(service.bot.telegram.setWebhook).toHaveBeenCalledWith(
+      'https://example.com/webhook/secret',
+      expect.any(Object),
+    );
+  });
+
+  it('syncs only /help and /status before polling starts', async () => {
+    const service = await createService();
+
+    await service.startPolling();
+
+    expect(service.bot.telegram.setMyCommands).toHaveBeenCalledWith([
+      { command: 'help', description: 'Show available commands and supported inputs' },
+      { command: 'status', description: 'Show bot health, uptime, and dependency status' },
+    ]);
+    expect(service.bot.launch).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Improve the Telegram command surface so the bot is immediately usable via `/help` and `/status`, and make `/status` operationally useful.

## Why
Issue #14 called out two user-facing gaps: the supported command surface was misleading, and `/status` did not provide enough runtime health information to debug live problems.

## Changes made
- remove `/start` from the registered and advertised Telegram command set
- sync Telegram command menu so only `/help` and `/status` appear in the slash-command picker
- add in-process activity tracking plus a status service for uptime, GPT model, Todoist reachability, and recent activity
- update command handlers, Telegram wiring, tests, and docs to match the new behavior

## Testing
- `npm run build`
- `npm test -- --runInBand`

## Notes
- Todoist health is reported as degraded instead of throwing when the live dependency check fails.
- Activity metrics are intentionally in-memory only for this issue scope.
