### PR TITLE
[Feature] add SQLite persistence layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "express": "^5.1.0",
         "fluent-ffmpeg": "^2.1.3",
         "openai": "^5.0.2",
+        "sqlite3": "^6.0.1",
         "telegraf": "^4.16.3",
         "todoist-mcp": "^1.2.3",
         "winston": "^3.17.0"
@@ -1177,6 +1178,15 @@
         "win32"
       ]
     },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1241,6 +1251,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2224,6 +2245,52 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@npmcli/agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "optional": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -2859,6 +2926,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2918,6 +2994,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -3254,7 +3339,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3284,11 +3368,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -3400,7 +3491,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3457,6 +3547,89 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+      "optional": true,
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cacache/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "optional": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cacache/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "optional": true,
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "optional": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/cachedir": {
@@ -3592,6 +3765,14 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
@@ -4282,12 +4463,34 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4354,6 +4557,14 @@
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "engines": {
         "node": ">=8"
       }
@@ -4502,11 +4713,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5142,6 +5361,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -5171,6 +5398,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "optional": true
     },
     "node_modules/express": {
       "version": "5.1.0",
@@ -5388,6 +5621,11 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -5637,6 +5875,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -5651,6 +5894,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -5795,6 +6050,11 @@
         "node": ">=16"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5927,7 +6187,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -6007,6 +6267,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "optional": true
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6021,6 +6287,32 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -6049,7 +6341,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6280,6 +6571,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -9186,6 +9486,29 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/make-fetch-happen": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
+      "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+      "optional": true,
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -9344,6 +9667,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -9361,11 +9695,151 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "optional": true
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "optional": true
+    },
+    "node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -9402,6 +9876,11 @@
         "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -9416,6 +9895,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-fetch": {
@@ -9436,6 +9934,54 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
+      "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^15.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/node-int64": {
@@ -9479,6 +10025,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/normalize-path": {
@@ -9752,6 +10313,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-timeout": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
@@ -9857,6 +10430,31 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "optional": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "optional": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
@@ -9998,6 +10596,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10065,6 +10689,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -10098,6 +10731,15 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -10183,6 +10825,33 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -10456,7 +11125,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10608,6 +11276,49 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -10670,6 +11381,44 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10707,6 +11456,44 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sqlite3": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-6.0.1.tgz",
+      "integrity": "sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^8.0.0",
+        "prebuild-install": "^7.1.3",
+        "tar": "^7.5.10"
+      },
+      "engines": {
+        "node": ">=20.17.0"
+      },
+      "optionalDependencies": {
+        "node-gyp": "12.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "12.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ssri": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -10930,6 +11717,60 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/telegraf": {
       "version": "4.16.3",
       "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
@@ -10999,6 +11840,51 @@
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "optional": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -11210,6 +12096,17 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "express": "^5.1.0",
     "fluent-ffmpeg": "^2.1.3",
     "openai": "^5.0.2",
+    "sqlite3": "^6.0.1",
     "telegraf": "^4.16.3",
     "todoist-mcp": "^1.2.3",
     "winston": "^3.17.0"

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,19 @@ import { TelegramBotService } from './services/telegram/telegram-bot.service';
 import { MessageProcessorService } from './services/telegram/message-processor.service';
 import { TelegramConfig } from './types/telegram.types';
 import { DirectToolCallDispatcher } from './services/tools/direct-tool-dispatcher.service';
+import {
+  ClarificationStateService,
+  ConversationStoreService,
+  DatabaseService,
+  JobRepository,
+  JobStateService,
+  MessageRepository,
+  MigrationRunner,
+  PendingClarificationRepository,
+  UsageEventRepository,
+  UsageTrackingService,
+  UserPreferencesRepository,
+} from './services/persistence';
 
 // Validate required environment variables before constructing any service
 const REQUIRED_ENV_VARS = [
@@ -25,17 +38,66 @@ for (const key of REQUIRED_ENV_VARS) {
 const BOT_TOKEN = process.env.BOT_TOKEN!;
 const NGROK_URL = process.env.NGROK_URL!;
 const TELEGRAM_SECRET_TOKEN = process.env.TELEGRAM_SECRET_TOKEN!;
+const DATABASE_PATH = process.env.DATABASE_PATH || './data/jarvis.db';
+const DATABASE_VERBOSE_LOGGING = process.env.DATABASE_VERBOSE_LOGGING === 'true';
 
-// Wire up services
-const toolDispatcher = new DirectToolCallDispatcher();
-const messageProcessor = new MessageProcessorService(toolDispatcher);
+export interface AppServices {
+  botService: TelegramBotService;
+  databaseService: DatabaseService;
+  conversationStore: ConversationStoreService;
+  jobStateService: JobStateService;
+  clarificationStateService: ClarificationStateService;
+  usageTrackingService: UsageTrackingService;
+  userPreferencesRepository: UserPreferencesRepository;
+}
 
-const telegramConfig: TelegramConfig = {
-  token: BOT_TOKEN,
-  webhookUrl: NGROK_URL,
-  secretToken: TELEGRAM_SECRET_TOKEN,
-};
+export async function initializeApplication(): Promise<AppServices> {
+  const databaseService = new DatabaseService({
+    path: DATABASE_PATH,
+    verboseLogging: DATABASE_VERBOSE_LOGGING,
+  });
+  await databaseService.init();
 
-export const botService = new TelegramBotService(telegramConfig, messageProcessor);
+  const migrationRunner = new MigrationRunner(databaseService);
+  await migrationRunner.runMigrations();
 
-logger.info('Services initialised');
+  const messageRepository = new MessageRepository(databaseService);
+  const jobRepository = new JobRepository(databaseService);
+  const clarificationRepository = new PendingClarificationRepository(databaseService);
+  const userPreferencesRepository = new UserPreferencesRepository(databaseService);
+  const usageEventRepository = new UsageEventRepository(databaseService);
+
+  const conversationStore = new ConversationStoreService(messageRepository);
+  const jobStateService = new JobStateService(jobRepository);
+  const clarificationStateService = new ClarificationStateService(clarificationRepository);
+  const usageTrackingService = new UsageTrackingService(usageEventRepository);
+
+  const toolDispatcher = new DirectToolCallDispatcher();
+  const messageProcessor = new MessageProcessorService(toolDispatcher, usageTrackingService);
+
+  const telegramConfig: TelegramConfig = {
+    token: BOT_TOKEN,
+    webhookUrl: NGROK_URL,
+    secretToken: TELEGRAM_SECRET_TOKEN,
+  };
+
+  const botService = new TelegramBotService(telegramConfig, messageProcessor, {
+    conversationStore,
+    jobStateService,
+    usageTrackingService,
+  });
+
+  logger.info('Services initialised', {
+    databasePath: DATABASE_PATH,
+  });
+
+  return {
+    botService,
+    databaseService,
+    conversationStore,
+    jobStateService,
+    clarificationStateService,
+    usageTrackingService,
+    userPreferencesRepository,
+  };
+}

--- a/src/controllers/webhook.controller.ts
+++ b/src/controllers/webhook.controller.ts
@@ -2,8 +2,13 @@
 import express from 'express';
 import type { TelegramBotService } from '../services/telegram/telegram-bot.service';
 import { logger } from '../utils/logger';
+import { ConversationStoreService, UsageTrackingService } from '../services/persistence';
 
-export function createWebhookRouter(botService: TelegramBotService) {
+export function createWebhookRouter(
+  botService: TelegramBotService,
+  conversationStore?: ConversationStoreService,
+  usageTrackingService?: UsageTrackingService,
+) {
   const router = express.Router();
 
   router.post('/webhook/:secret', express.json(), async (req, res): Promise<void> => {
@@ -14,6 +19,31 @@ export function createWebhookRouter(botService: TelegramBotService) {
       return;
     }
     try {
+      const updateId = typeof req.body?.update_id === 'number' ? req.body.update_id : undefined;
+      if (updateId) {
+        const existingMessage = await conversationStore?.findByTelegramUpdateId(updateId);
+        if (existingMessage) {
+          logger.info('Skipping duplicate Telegram update', {
+            telegramUpdateId: updateId,
+            messageId: existingMessage.id,
+          });
+          res.sendStatus(200);
+          return;
+        }
+      }
+
+      const from = req.body?.message?.from ?? req.body?.callback_query?.from;
+      const chat = req.body?.message?.chat ?? req.body?.callback_query?.message?.chat;
+      await usageTrackingService?.recordEvent({
+        userId: from?.id?.toString(),
+        chatId: chat?.id?.toString(),
+        eventType: 'message_received',
+        metadata: {
+          updateId: updateId ?? null,
+          updateKeys: req.body ? Object.keys(req.body) : [],
+        },
+      });
+
       await botService.handleUpdate(req.body);
       res.sendStatus(200);
       return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,39 +2,48 @@
 import express, { Request, Response, NextFunction } from 'express';
 import { logger } from './utils/logger';
 import { createWebhookRouter } from './controllers/webhook.controller';
-import { botService } from './app';
+import { initializeApplication } from './app';
 
 const NGROK_URL = process.env.NGROK_URL!;
 const TELEGRAM_SECRET_TOKEN = process.env.TELEGRAM_SECRET_TOKEN!;
 
-// Register webhook with Telegram (runs once per URL; safe to call on every start)
-(async () => {
+async function startServer(): Promise<void> {
+  const services = await initializeApplication();
+
   try {
-    await botService.setupWebhook(NGROK_URL, TELEGRAM_SECRET_TOKEN);
+    await services.botService.setupWebhook(NGROK_URL, TELEGRAM_SECRET_TOKEN);
   } catch (err) {
-    logger.error('Error setting up webhook:', err);
+    logger.error('Error setting up webhook', {
+      error: (err as Error).message,
+    });
   }
-})();
 
-// Express app
-const app = express();
-app.use(express.json());
+  const app = express();
+  app.use(express.json());
 
-app.get('/ping', (_req: Request, res: Response, _next: NextFunction) => {
-  res.json({ status: 'ok' });
-});
+  app.get('/ping', (_req: Request, res: Response, _next: NextFunction) => {
+    res.json({ status: 'ok' });
+  });
 
-app.use(createWebhookRouter(botService));
+  app.use(
+    createWebhookRouter(
+      services.botService,
+      services.conversationStore,
+      services.usageTrackingService,
+    ),
+  );
 
-// Start listening
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  logger.info(`Server started at http://localhost:${PORT}`);
-  logger.info(`Waiting for Telegram updates on /webhook/:secret`);
-});
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    logger.info(`Server started at http://localhost:${PORT}`);
+    logger.info(`Waiting for Telegram updates on /webhook/:secret`);
+  });
 
-// Graceful shutdown
-process.on('SIGTERM', () => {
-  logger.info('Shutting down gracefully...');
-  process.exit(0);
-});
+  process.on('SIGTERM', async () => {
+    logger.info('Shutting down gracefully...');
+    await services.databaseService.close();
+    process.exit(0);
+  });
+}
+
+void startServer();

--- a/src/services/ai/gpt.service.ts
+++ b/src/services/ai/gpt.service.ts
@@ -22,6 +22,8 @@ import { GPTValidator } from './validators/gpt.validator';
 import { GPTErrorHandler } from './errors/gpt-error-handler.service';
 import { FunctionCallingProcessor } from './processors/function-calling.processor';
 import { SimpleTextProcessor } from './processors/simple-text.processor';
+import { UsageTrackingService } from '../persistence';
+import { ProcessingContext } from '../../types/processing.types';
 
 /**
  * Service for generating text content using OpenAI GPT models with function calling
@@ -33,6 +35,7 @@ export class GPTService {
   private readonly functionCallingProcessor: FunctionCallingProcessor;
   private readonly simpleTextProcessor: SimpleTextProcessor;
   private readonly toolDispatcher?: ToolDispatcher;
+  private readonly usageTrackingService?: UsageTrackingService;
 
   /**
    * Creates a new GPTService instance
@@ -41,7 +44,11 @@ export class GPTService {
    * @param config - Configuration options for the service
    * @throws {Error} If OpenAI API key is not provided
    */
-  constructor(toolDispatcher?: ToolDispatcher, config?: Partial<GPTConfig>) {
+  constructor(
+    toolDispatcher?: ToolDispatcher,
+    config?: Partial<GPTConfig>,
+    usageTrackingService?: UsageTrackingService,
+  ) {
     const apiKey = config?.apiKey || process.env.OPENAI_API_KEY;
 
     // Validate configuration
@@ -49,6 +56,7 @@ export class GPTService {
 
     this.openai = new OpenAI({ apiKey });
     this.toolDispatcher = toolDispatcher;
+    this.usageTrackingService = usageTrackingService;
     this.enableFunctionCalling = config?.enableFunctionCalling !== false && !!toolDispatcher;
 
     // Set default configuration with provided overrides
@@ -60,7 +68,10 @@ export class GPTService {
     };
 
     // Initialize processors
-    this.functionCallingProcessor = new FunctionCallingProcessor(toolDispatcher);
+    this.functionCallingProcessor = new FunctionCallingProcessor(
+      toolDispatcher,
+      usageTrackingService,
+    );
     this.simpleTextProcessor = new SimpleTextProcessor();
 
     logger.info('GPTService initialized', {
@@ -78,7 +89,16 @@ export class GPTService {
    * @param userId - User identifier for context/authorization
    * @returns Promise<string> - The final response to send back to user
    */
-  async processMessage(message: string, userId?: string): Promise<string> {
+  async processMessage(message: string, userId?: string, context?: ProcessingContext): Promise<string> {
+    const result = await this.processMessageDetailed(message, userId, context);
+    return result.response;
+  }
+
+  async processMessageDetailed(
+    message: string,
+    userId?: string,
+    context?: ProcessingContext,
+  ): Promise<MessageProcessingResult> {
     const startTime = Date.now();
 
     logger.info('Processing message with GPT', {
@@ -96,25 +116,57 @@ export class GPTService {
         GPTValidator.validateInputMessage(message, this.config.maxInputLength);
 
         // Process with function calling if enabled
+        await this.usageTrackingService?.recordEvent({
+          userId,
+          chatId: context?.chatId,
+          jobId: context?.jobId,
+          messageId: context?.sourceMessageId,
+          eventType: 'gpt_request',
+          model: this.config.model,
+          metadata: {
+            functionCallingEnabled: this.enableFunctionCalling,
+            messageLength: message.length,
+          },
+        });
+
+        let result: MessageProcessingResult;
+
         if (this.enableFunctionCalling) {
-          const result = await this.functionCallingProcessor.processWithFunctionCalling(
+          result = await this.functionCallingProcessor.processWithFunctionCalling(
             this.openai,
             this.config.model,
             this.config.temperature,
             message,
             userId || 'anonymous',
           );
-          return result.response;
+        } else {
+          result = await this.simpleTextProcessor.processSimpleMessage(
+            this.openai,
+            this.config.model,
+            this.config.temperature,
+            message,
+            userId,
+          );
         }
 
-        // Fallback to simple text generation
-        return await this.simpleTextProcessor.processSimpleMessage(
-          this.openai,
-          this.config.model,
-          this.config.temperature,
-          message,
+        await this.usageTrackingService?.recordEvent({
           userId,
-        );
+          chatId: context?.chatId,
+          jobId: context?.jobId,
+          messageId: context?.sourceMessageId,
+          eventType: 'gpt_response',
+          model: result.model,
+          inputTokens: result.inputTokens,
+          outputTokens: result.outputTokens,
+          estimatedCostUsd: result.estimatedCostUsd,
+          durationMs: result.processingTimeMs,
+          metadata: {
+            functionCallsCount: result.functionCallsCount,
+            usedFunctionCalling: result.usedFunctionCalling,
+          },
+        });
+
+        return result;
       } catch (error) {
         lastError = error as Error;
 
@@ -143,7 +195,28 @@ export class GPTService {
       processingTimeMs,
     });
 
-    return GPTErrorHandler.handleProcessingError(lastError!);
+    await this.usageTrackingService?.recordEvent({
+      userId,
+      chatId: context?.chatId,
+      jobId: context?.jobId,
+      messageId: context?.sourceMessageId,
+      eventType: 'error',
+      model: this.config.model,
+      durationMs: processingTimeMs,
+      metadata: {
+        source: 'gpt',
+        error: lastError!.message,
+      },
+    });
+
+    return {
+      response: GPTErrorHandler.handleProcessingError(lastError!),
+      originalMessage: message,
+      processingTimeMs,
+      usedFunctionCalling: this.enableFunctionCalling,
+      functionCallsCount: 0,
+      model: this.config.model,
+    };
   }
 
   /**

--- a/src/services/ai/processors/function-calling.processor.ts
+++ b/src/services/ai/processors/function-calling.processor.ts
@@ -11,6 +11,7 @@ import { GPT_CONSTANTS } from '../constants/gpt.constants';
 import { getFunctionCallingSystemPrompt, FINAL_RESPONSE_PROMPT } from '../../../types/gpt.prompts';
 import { GPTToolsService } from '../../tools/todoist-tools.service';
 import { ToolDispatcher, ToolCall } from '../../../types/tool.types';
+import { UsageTrackingService } from '../../persistence';
 
 /**
  * Processor for handling GPT function calling capabilities
@@ -18,7 +19,10 @@ import { ToolDispatcher, ToolCall } from '../../../types/tool.types';
 export class FunctionCallingProcessor {
   private readonly toolsService: GPTToolsService;
 
-  constructor(private readonly toolDispatcher?: ToolDispatcher) {
+  constructor(
+    private readonly toolDispatcher?: ToolDispatcher,
+    private readonly usageTrackingService?: UsageTrackingService,
+  ) {
     this.toolsService = new GPTToolsService(toolDispatcher);
   }
 
@@ -62,6 +66,8 @@ export class FunctionCallingProcessor {
       });
 
       const responseMessage = response.choices[0].message;
+      const initialInputTokens = response.usage?.prompt_tokens || 0;
+      const initialOutputTokens = response.usage?.completion_tokens || 0;
 
       // Log the full GPT response for inspection
       logger.debug('GPT function calling response', {
@@ -89,6 +95,9 @@ export class FunctionCallingProcessor {
           usedFunctionCalling: true,
           functionCallsCount: responseMessage.tool_calls.length,
           model,
+          inputTokens: initialInputTokens,
+          outputTokens: initialOutputTokens,
+          totalTokens: response.usage?.total_tokens,
         };
       }
 
@@ -103,6 +112,9 @@ export class FunctionCallingProcessor {
         usedFunctionCalling: false,
         functionCallsCount: 0,
         model,
+        inputTokens: initialInputTokens,
+        outputTokens: initialOutputTokens,
+        totalTokens: response.usage?.total_tokens,
       };
     } catch (error) {
       logger.error('Function calling processing failed', {
@@ -156,6 +168,17 @@ export class FunctionCallingProcessor {
         })),
       });
 
+      for (const toolCall of toolCalls) {
+        await this.usageTrackingService?.recordEvent({
+          userId,
+          eventType: 'tool_called',
+          metadata: {
+            toolCallId: toolCall.id,
+            functionName: toolCall.function.name,
+          },
+        });
+      }
+
       // Filter out any function names the dispatcher does not support
       const supportedCalls = toolCalls.filter((tc) => {
         if (this.toolDispatcher!.isFunctionSupported(tc.function.name)) return true;
@@ -179,6 +202,18 @@ export class FunctionCallingProcessor {
           error: result.error,
         })),
       });
+
+      for (const result of toolResults) {
+        await this.usageTrackingService?.recordEvent({
+          userId,
+          eventType: 'tool_completed',
+          metadata: {
+            toolCallId: result.tool_call_id,
+            success: !result.error,
+            error: result.error ?? null,
+          },
+        });
+      }
 
       // Generate final response based on tool execution results
       const finalResponse = await this.generateFinalResponse(

--- a/src/services/ai/processors/simple-text.processor.ts
+++ b/src/services/ai/processors/simple-text.processor.ts
@@ -8,6 +8,7 @@ import OpenAI from 'openai';
 import { logger } from '../../../utils/logger';
 import { GPT_CONSTANTS } from '../constants/gpt.constants';
 import { SIMPLE_CONVERSATION_PROMPT } from '../../../types/gpt.prompts';
+import { MessageProcessingResult } from '../../../types/gpt.types';
 
 /**
  * Processor for handling simple text generation without function calling
@@ -29,7 +30,9 @@ export class SimpleTextProcessor {
     temperature: number,
     message: string,
     userId?: string,
-  ): Promise<string> {
+  ): Promise<MessageProcessingResult> {
+    const startTime = Date.now();
+
     try {
       const completion = await openai.chat.completions.create({
         model,
@@ -47,10 +50,19 @@ export class SimpleTextProcessor {
         temperature,
       });
 
-      return (
-        completion.choices[0]?.message?.content ||
-        "I apologize, but I couldn't generate a response."
-      );
+      return {
+        response:
+          completion.choices[0]?.message?.content ||
+          "I apologize, but I couldn't generate a response.",
+        originalMessage: message,
+        processingTimeMs: Date.now() - startTime,
+        usedFunctionCalling: false,
+        functionCallsCount: 0,
+        model,
+        inputTokens: completion.usage?.prompt_tokens,
+        outputTokens: completion.usage?.completion_tokens,
+        totalTokens: completion.usage?.total_tokens,
+      };
     } catch (error) {
       logger.error('Simple message processing failed', {
         userId,

--- a/src/services/ai/whisper.service.ts
+++ b/src/services/ai/whisper.service.ts
@@ -16,6 +16,8 @@ import { logger } from '../../utils/logger';
 import { AudioMimeTypes } from '../../utils/constants';
 import { validateFileSize } from '../../utils/ai/fileValidation';
 import { AudioConverter } from '../../utils/ai/audioConverter';
+import { UsageTrackingService } from '../persistence';
+import { ProcessingContext } from '../../types/processing.types';
 
 /**
  * Constants for Whisper service configuration
@@ -71,6 +73,7 @@ export class WhisperService {
   private readonly openai: OpenAI;
   private readonly config: Required<Omit<WhisperConfig, 'language'>>;
   private readonly language: string;
+  private readonly usageTrackingService?: UsageTrackingService;
 
   /**
    * Creates a new WhisperService instance
@@ -78,7 +81,7 @@ export class WhisperService {
    * @param config - Configuration options for the service
    * @throws {Error} If OpenAI API key is not provided
    */
-  constructor(config?: Partial<WhisperConfig>) {
+  constructor(config?: Partial<WhisperConfig>, usageTrackingService?: UsageTrackingService) {
     const apiKey = config?.apiKey || process.env.OPENAI_API_KEY;
 
     if (!apiKey) {
@@ -88,6 +91,7 @@ export class WhisperService {
     }
 
     this.openai = new OpenAI({ apiKey });
+    this.usageTrackingService = usageTrackingService;
 
     // Set default configuration with provided overrides
     // Always enforce English-only transcription unless explicitly disabled
@@ -123,7 +127,11 @@ export class WhisperService {
    * @returns Promise resolving to transcription result
    * @throws {Error} If file download fails, file is too large, or transcription fails
    */
-  async transcribeAudio(fileUrl: string, userId?: number): Promise<TranscriptionResult> {
+  async transcribeAudio(
+    fileUrl: string,
+    userId?: number,
+    context?: ProcessingContext,
+  ): Promise<TranscriptionResult> {
     const startTime = Date.now();
 
     logger.info('Starting audio transcription', {
@@ -230,6 +238,20 @@ export class WhisperService {
 
       logger.info('Audio transcription completed successfully', logData);
 
+      await this.usageTrackingService?.recordEvent({
+        userId: userId?.toString(),
+        chatId: context?.chatId,
+        jobId: context?.jobId,
+        messageId: context?.sourceMessageId,
+        eventType: 'audio_transcription',
+        model: this.config.model,
+        durationMs: processingTimeMs,
+        metadata: {
+          fileSizeBytes: processedBuffer.length,
+          detectedLanguage: result.detectedLanguage ?? null,
+        },
+      });
+
       return result;
     } catch (error) {
       const processingTimeMs = Date.now() - startTime;
@@ -239,6 +261,20 @@ export class WhisperService {
         fileUrl: this.sanitizeUrlForLogging(fileUrl),
         error: (error as Error).message,
         processingTimeMs,
+      });
+
+      await this.usageTrackingService?.recordEvent({
+        userId: userId?.toString(),
+        chatId: context?.chatId,
+        jobId: context?.jobId,
+        messageId: context?.sourceMessageId,
+        eventType: 'error',
+        model: this.config.model,
+        durationMs: processingTimeMs,
+        metadata: {
+          source: 'whisper',
+          error: (error as Error).message,
+        },
       });
 
       throw new Error(`Transcription failed: ${(error as Error).message}`);

--- a/src/services/persistence/clarification-state.service.ts
+++ b/src/services/persistence/clarification-state.service.ts
@@ -1,0 +1,32 @@
+import { PendingClarificationRepository } from './repositories/pending-clarification.repository';
+import { CreatePendingClarificationInput, PendingClarificationRecord } from './types';
+
+export class ClarificationStateService {
+  constructor(private readonly clarificationRepository: PendingClarificationRepository) {}
+
+  createPendingClarification(
+    input: CreatePendingClarificationInput,
+  ): Promise<PendingClarificationRecord> {
+    return this.clarificationRepository.createPendingClarification(input);
+  }
+
+  findActiveByUser(userId: string): Promise<PendingClarificationRecord | null> {
+    return this.clarificationRepository.findActiveByUser(userId);
+  }
+
+  resolveClarification(
+    clarificationId: string,
+    status: 'answered' | 'expired' | 'cancelled',
+    answerMessageId?: string,
+  ): Promise<void> {
+    return this.clarificationRepository.resolveClarification(
+      clarificationId,
+      status,
+      answerMessageId,
+    );
+  }
+
+  expireClarifications(now: string): Promise<number> {
+    return this.clarificationRepository.expireClarifications(now);
+  }
+}

--- a/src/services/persistence/conversation-store.service.ts
+++ b/src/services/persistence/conversation-store.service.ts
@@ -1,0 +1,36 @@
+import { MessageRepository } from './repositories/message.repository';
+import {
+  CreateIncomingMessageInput,
+  CreateOutgoingMessageInput,
+  PersistedMessage,
+  PersistedMessageStatus,
+} from './types';
+
+export class ConversationStoreService {
+  constructor(private readonly messageRepository: MessageRepository) {}
+
+  createIncomingMessage(input: CreateIncomingMessageInput): Promise<PersistedMessage> {
+    return this.messageRepository.createIncomingMessage(input);
+  }
+
+  createOutgoingMessage(input: CreateOutgoingMessageInput): Promise<PersistedMessage> {
+    return this.messageRepository.createOutgoingMessage(input);
+  }
+
+  markMessageProcessing(
+    messageId: string,
+    status: PersistedMessageStatus,
+    errorMessage?: string,
+    jobId?: string,
+  ): Promise<void> {
+    return this.messageRepository.markMessageProcessing(messageId, status, errorMessage, jobId);
+  }
+
+  listRecentMessagesByUser(userId: string, limit: number): Promise<PersistedMessage[]> {
+    return this.messageRepository.listRecentMessagesByUser(userId, limit);
+  }
+
+  findByTelegramUpdateId(updateId: number): Promise<PersistedMessage | null> {
+    return this.messageRepository.findByTelegramUpdateId(updateId);
+  }
+}

--- a/src/services/persistence/database.service.ts
+++ b/src/services/persistence/database.service.ts
@@ -1,0 +1,159 @@
+import fs from 'fs';
+import path from 'path';
+import sqlite3 from 'sqlite3';
+import { logger } from '../../utils/logger';
+import { DatabaseConfig } from './types';
+
+type SQLiteDatabase = sqlite3.Database;
+
+export class DatabaseService {
+  private db: SQLiteDatabase | null = null;
+
+  constructor(private readonly config: DatabaseConfig) {}
+
+  async init(): Promise<void> {
+    const dbDirectory = path.dirname(this.config.path);
+    fs.mkdirSync(dbDirectory, { recursive: true });
+
+    this.db = await new Promise<SQLiteDatabase>((resolve, reject) => {
+      const database = new sqlite3.Database(this.config.path, (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(database);
+      });
+    });
+
+    await this.exec('PRAGMA foreign_keys = ON;');
+    await this.exec('PRAGMA journal_mode = WAL;');
+    await this.exec('PRAGMA busy_timeout = 5000;');
+
+    logger.info('Database initialized', {
+      dbOperation: 'init',
+      path: this.config.path,
+      verboseLogging: this.config.verboseLogging,
+    });
+  }
+
+  async close(): Promise<void> {
+    if (!this.db) {
+      return;
+    }
+
+    const db = this.db;
+    this.db = null;
+
+    await new Promise<void>((resolve, reject) => {
+      db.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+
+  async run(sql: string, params: unknown[] = []): Promise<{ lastID: number; changes: number }> {
+    const db = this.getDb();
+    this.logQuery('run', sql, params);
+
+    return new Promise((resolve, reject) => {
+      db.run(sql, params, function onRun(error) {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve({
+          lastID: this.lastID,
+          changes: this.changes,
+        });
+      });
+    });
+  }
+
+  async get<T>(sql: string, params: unknown[] = []): Promise<T | undefined> {
+    const db = this.getDb();
+    this.logQuery('get', sql, params);
+
+    return new Promise((resolve, reject) => {
+      db.get(sql, params, (error, row) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(row as T | undefined);
+      });
+    });
+  }
+
+  async all<T>(sql: string, params: unknown[] = []): Promise<T[]> {
+    const db = this.getDb();
+    this.logQuery('all', sql, params);
+
+    return new Promise((resolve, reject) => {
+      db.all(sql, params, (error, rows) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve((rows as T[]) || []);
+      });
+    });
+  }
+
+  async exec(sql: string): Promise<void> {
+    const db = this.getDb();
+    this.logQuery('exec', sql);
+
+    await new Promise<void>((resolve, reject) => {
+      db.exec(sql, (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+
+  async transaction<T>(fn: () => Promise<T>): Promise<T> {
+    await this.exec('BEGIN');
+
+    try {
+      const result = await fn();
+      await this.exec('COMMIT');
+      return result;
+    } catch (error) {
+      await this.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  private getDb(): SQLiteDatabase {
+    if (!this.db) {
+      throw new Error('Database has not been initialized');
+    }
+
+    return this.db;
+  }
+
+  private logQuery(kind: string, sql: string, params?: unknown[]): void {
+    if (!this.config.verboseLogging) {
+      return;
+    }
+
+    logger.debug('Executing database query', {
+      dbOperation: kind,
+      sql,
+      params,
+    });
+  }
+}

--- a/src/services/persistence/index.ts
+++ b/src/services/persistence/index.ts
@@ -1,0 +1,12 @@
+export { DatabaseService } from './database.service';
+export { MigrationRunner } from './migration-runner.service';
+export { ConversationStoreService } from './conversation-store.service';
+export { JobStateService } from './job-state.service';
+export { ClarificationStateService } from './clarification-state.service';
+export { UsageTrackingService } from './usage-tracking.service';
+export { MessageRepository } from './repositories/message.repository';
+export { JobRepository } from './repositories/job.repository';
+export { PendingClarificationRepository } from './repositories/pending-clarification.repository';
+export { UserPreferencesRepository } from './repositories/user-preferences.repository';
+export { UsageEventRepository } from './repositories/usage-event.repository';
+export * from './types';

--- a/src/services/persistence/job-state.service.ts
+++ b/src/services/persistence/job-state.service.ts
@@ -1,0 +1,30 @@
+import { JobRepository } from './repositories/job.repository';
+import { CreateJobInput, PersistedJob } from './types';
+
+export class JobStateService {
+  constructor(private readonly jobRepository: JobRepository) {}
+
+  createJob(input: CreateJobInput): Promise<PersistedJob> {
+    return this.jobRepository.createJob(input);
+  }
+
+  markInProgress(jobId: string): Promise<void> {
+    return this.jobRepository.markInProgress(jobId);
+  }
+
+  markCompleted(jobId: string, result: Record<string, unknown>): Promise<void> {
+    return this.jobRepository.markCompleted(jobId, result);
+  }
+
+  markFailed(jobId: string, error: string, result?: Record<string, unknown>): Promise<void> {
+    return this.jobRepository.markFailed(jobId, error, result);
+  }
+
+  getJob(jobId: string): Promise<PersistedJob | null> {
+    return this.jobRepository.getJob(jobId);
+  }
+
+  listActiveJobsByUser(userId: string): Promise<PersistedJob[]> {
+    return this.jobRepository.listActiveJobsByUser(userId);
+  }
+}

--- a/src/services/persistence/migration-runner.service.ts
+++ b/src/services/persistence/migration-runner.service.ts
@@ -1,0 +1,57 @@
+import { logger } from '../../utils/logger';
+import { DatabaseService } from './database.service';
+import { nowIso } from './utils';
+import { migration001Initial } from './migrations/001_initial';
+
+interface MigrationDefinition {
+  version: number;
+  name: string;
+  sql: string;
+}
+
+const MIGRATIONS: MigrationDefinition[] = [
+  {
+    version: 1,
+    name: 'initial_persistence_schema',
+    sql: migration001Initial,
+  },
+];
+
+interface AppliedMigrationRow {
+  version: number;
+}
+
+export class MigrationRunner {
+  constructor(private readonly database: DatabaseService) {}
+
+  async runMigrations(): Promise<void> {
+    await this.database.exec(
+      'CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL);',
+    );
+
+    const appliedRows = await this.database.all<AppliedMigrationRow>(
+      'SELECT version FROM schema_migrations',
+    );
+    const applied = new Set(appliedRows.map((row) => row.version));
+
+    for (const migration of MIGRATIONS) {
+      if (applied.has(migration.version)) {
+        continue;
+      }
+
+      await this.database.transaction(async () => {
+        await this.database.exec(migration.sql);
+        await this.database.run(
+          'INSERT INTO schema_migrations (version, name, applied_at) VALUES (?, ?, ?)',
+          [migration.version, migration.name, nowIso()],
+        );
+      });
+
+      logger.info('Applied database migration', {
+        dbOperation: 'migration',
+        version: migration.version,
+        name: migration.name,
+      });
+    }
+  }
+}

--- a/src/services/persistence/migrations/001_initial.ts
+++ b/src/services/persistence/migrations/001_initial.ts
@@ -1,0 +1,111 @@
+export const migration001Initial = `
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  version INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  applied_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id TEXT PRIMARY KEY,
+  telegram_update_id INTEGER,
+  telegram_message_id INTEGER,
+  chat_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  direction TEXT NOT NULL,
+  message_type TEXT NOT NULL,
+  content_text TEXT,
+  file_id TEXT,
+  file_url TEXT,
+  file_name TEXT,
+  mime_type TEXT,
+  reply_to_message_id TEXT,
+  job_id TEXT,
+  status TEXT NOT NULL DEFAULT 'processed',
+  error_message TEXT,
+  created_at TEXT NOT NULL,
+  processed_at TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_update_direction
+  ON messages (telegram_update_id, direction)
+  WHERE telegram_update_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_messages_user_created_at ON messages (user_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_chat_created_at ON messages (chat_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_job_id ON messages (job_id);
+
+CREATE TABLE IF NOT EXISTS jobs (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  chat_id TEXT NOT NULL,
+  source_message_id TEXT,
+  job_type TEXT NOT NULL,
+  status TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  result_json TEXT,
+  error_message TEXT,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  started_at TEXT,
+  completed_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_user_created_at ON jobs (user_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_jobs_chat_created_at ON jobs (chat_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_jobs_status_created_at ON jobs (status, created_at);
+
+CREATE TABLE IF NOT EXISTS pending_clarifications (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  chat_id TEXT NOT NULL,
+  source_message_id TEXT,
+  job_id TEXT,
+  status TEXT NOT NULL,
+  intent_name TEXT,
+  confidence_score REAL,
+  question_text TEXT NOT NULL,
+  proposed_action_json TEXT,
+  answer_message_id TEXT,
+  expires_at TEXT,
+  created_at TEXT NOT NULL,
+  resolved_at TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_clarifications_active_user_chat
+  ON pending_clarifications (user_id, chat_id)
+  WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_pending_clarifications_user_status_created
+  ON pending_clarifications (user_id, status, created_at);
+
+CREATE TABLE IF NOT EXISTS user_preferences (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  preference_key TEXT NOT NULL,
+  preference_value_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_preferences_user_key
+  ON user_preferences (user_id, preference_key);
+
+CREATE TABLE IF NOT EXISTS usage_events (
+  id TEXT PRIMARY KEY,
+  user_id TEXT,
+  chat_id TEXT,
+  job_id TEXT,
+  message_id TEXT,
+  event_type TEXT NOT NULL,
+  model TEXT,
+  input_tokens INTEGER,
+  output_tokens INTEGER,
+  estimated_cost_usd REAL,
+  duration_ms INTEGER,
+  metadata_json TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_usage_events_user_created_at ON usage_events (user_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_usage_events_job_created_at ON usage_events (job_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_usage_events_type_created_at ON usage_events (event_type, created_at);
+`;

--- a/src/services/persistence/repositories/job.repository.ts
+++ b/src/services/persistence/repositories/job.repository.ts
@@ -1,0 +1,125 @@
+import { DatabaseService } from '../database.service';
+import { CreateJobInput, JobStatus, PersistedJob } from '../types';
+import { generateId, nowIso, parseJsonObject, stringifyJson } from '../utils';
+
+interface JobRow {
+  id: string;
+  user_id: string;
+  chat_id: string;
+  source_message_id: string | null;
+  job_type: PersistedJob['jobType'];
+  status: PersistedJob['status'];
+  payload_json: string;
+  result_json: string | null;
+  error_message: string | null;
+  attempt_count: number;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export class JobRepository {
+  constructor(private readonly database: DatabaseService) {}
+
+  async createJob(input: CreateJobInput): Promise<PersistedJob> {
+    const id = generateId('job');
+    const createdAt = nowIso();
+
+    await this.database.run(
+      `INSERT INTO jobs (
+        id, user_id, chat_id, source_message_id, job_type, status, payload_json, result_json,
+        error_message, attempt_count, started_at, completed_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, 'queued', ?, NULL, NULL, 0, NULL, NULL, ?, ?)`,
+      [
+        id,
+        input.userId,
+        input.chatId,
+        input.sourceMessageId ?? null,
+        input.jobType,
+        JSON.stringify(input.payload),
+        createdAt,
+        createdAt,
+      ],
+    );
+
+    return {
+      id,
+      userId: input.userId,
+      chatId: input.chatId,
+      sourceMessageId: input.sourceMessageId ?? null,
+      jobType: input.jobType,
+      status: 'queued',
+      payload: input.payload,
+      result: null,
+      errorMessage: null,
+      attemptCount: 0,
+      startedAt: null,
+      completedAt: null,
+      createdAt,
+      updatedAt: createdAt,
+    };
+  }
+
+  async markInProgress(jobId: string): Promise<void> {
+    const now = nowIso();
+    await this.database.run(
+      `UPDATE jobs
+       SET status = 'in_progress', attempt_count = attempt_count + 1, started_at = COALESCE(started_at, ?), updated_at = ?
+       WHERE id = ?`,
+      [now, now, jobId],
+    );
+  }
+
+  async markCompleted(jobId: string, result: Record<string, unknown>): Promise<void> {
+    const now = nowIso();
+    await this.database.run(
+      `UPDATE jobs
+       SET status = 'completed', result_json = ?, error_message = NULL, completed_at = ?, updated_at = ?
+       WHERE id = ?`,
+      [JSON.stringify(result), now, now, jobId],
+    );
+  }
+
+  async markFailed(jobId: string, error: string, result?: Record<string, unknown>): Promise<void> {
+    const now = nowIso();
+    await this.database.run(
+      `UPDATE jobs
+       SET status = 'failed', result_json = COALESCE(?, result_json), error_message = ?, completed_at = ?, updated_at = ?
+       WHERE id = ?`,
+      [stringifyJson(result), error, now, now, jobId],
+    );
+  }
+
+  async getJob(jobId: string): Promise<PersistedJob | null> {
+    const row = await this.database.get<JobRow>('SELECT * FROM jobs WHERE id = ?', [jobId]);
+    return row ? this.mapRow(row) : null;
+  }
+
+  async listActiveJobsByUser(userId: string): Promise<PersistedJob[]> {
+    const rows = await this.database.all<JobRow>(
+      `SELECT * FROM jobs WHERE user_id = ? AND status IN ('queued', 'in_progress') ORDER BY created_at ASC`,
+      [userId],
+    );
+    return rows.map((row) => this.mapRow(row));
+  }
+
+  private mapRow(row: JobRow): PersistedJob {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      chatId: row.chat_id,
+      sourceMessageId: row.source_message_id,
+      jobType: row.job_type,
+      status: row.status,
+      payload: parseJsonObject(row.payload_json) || {},
+      result: parseJsonObject(row.result_json),
+      errorMessage: row.error_message,
+      attemptCount: row.attempt_count,
+      startedAt: row.started_at,
+      completedAt: row.completed_at,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+}

--- a/src/services/persistence/repositories/message.repository.ts
+++ b/src/services/persistence/repositories/message.repository.ts
@@ -1,0 +1,202 @@
+import { logger } from '../../../utils/logger';
+import { DatabaseService } from '../database.service';
+import {
+  CreateIncomingMessageInput,
+  CreateOutgoingMessageInput,
+  PersistedMessage,
+  PersistedMessageStatus,
+} from '../types';
+import { generateId, nowIso } from '../utils';
+
+interface MessageRow {
+  id: string;
+  telegram_update_id: number | null;
+  telegram_message_id: number | null;
+  chat_id: string;
+  user_id: string;
+  direction: PersistedMessage['direction'];
+  message_type: PersistedMessage['messageType'];
+  content_text: string | null;
+  file_id: string | null;
+  file_url: string | null;
+  file_name: string | null;
+  mime_type: string | null;
+  reply_to_message_id: string | null;
+  job_id: string | null;
+  status: PersistedMessage['status'];
+  error_message: string | null;
+  created_at: string;
+  processed_at: string | null;
+}
+
+export class MessageRepository {
+  constructor(private readonly database: DatabaseService) {}
+
+  async createIncomingMessage(input: CreateIncomingMessageInput): Promise<PersistedMessage> {
+    const id = generateId('msg');
+    const createdAt = nowIso();
+    const status = input.status || 'received';
+
+    try {
+      await this.database.run(
+        `INSERT INTO messages (
+          id, telegram_update_id, telegram_message_id, chat_id, user_id, direction, message_type,
+          content_text, file_id, file_url, file_name, mime_type, reply_to_message_id, job_id,
+          status, error_message, created_at, processed_at
+        ) VALUES (?, ?, ?, ?, ?, 'incoming', ?, ?, ?, ?, ?, ?, NULL, ?, ?, NULL, ?, NULL)`,
+        [
+          id,
+          input.telegramUpdateId ?? null,
+          input.telegramMessageId ?? null,
+          input.chatId,
+          input.userId,
+          input.messageType,
+          input.contentText ?? null,
+          input.fileId ?? null,
+          input.fileUrl ?? null,
+          input.fileName ?? null,
+          input.mimeType ?? null,
+          input.jobId ?? null,
+          status,
+          createdAt,
+        ],
+      );
+    } catch (error) {
+      logger.error('Failed to create incoming message', {
+        dbOperation: 'createIncomingMessage',
+        telegramUpdateId: input.telegramUpdateId,
+        userId: input.userId,
+        chatId: input.chatId,
+        error: (error as Error).message,
+      });
+      throw error;
+    }
+
+    return {
+      id,
+      telegramUpdateId: input.telegramUpdateId ?? null,
+      telegramMessageId: input.telegramMessageId ?? null,
+      chatId: input.chatId,
+      userId: input.userId,
+      direction: 'incoming',
+      messageType: input.messageType,
+      contentText: input.contentText ?? null,
+      fileId: input.fileId ?? null,
+      fileUrl: input.fileUrl ?? null,
+      fileName: input.fileName ?? null,
+      mimeType: input.mimeType ?? null,
+      replyToMessageId: null,
+      jobId: input.jobId ?? null,
+      status,
+      errorMessage: null,
+      createdAt,
+      processedAt: null,
+    };
+  }
+
+  async createOutgoingMessage(input: CreateOutgoingMessageInput): Promise<PersistedMessage> {
+    const id = generateId('msg');
+    const createdAt = nowIso();
+    const processedAt = nowIso();
+    const status = input.status || 'processed';
+
+    await this.database.run(
+      `INSERT INTO messages (
+        id, telegram_update_id, telegram_message_id, chat_id, user_id, direction, message_type,
+        content_text, file_id, file_url, file_name, mime_type, reply_to_message_id, job_id,
+        status, error_message, created_at, processed_at
+      ) VALUES (?, NULL, ?, ?, ?, 'outgoing', ?, ?, NULL, NULL, NULL, NULL, ?, ?, ?, NULL, ?, ?)`,
+      [
+        id,
+        input.telegramMessageId ?? null,
+        input.chatId,
+        input.userId,
+        input.messageType,
+        input.contentText ?? null,
+        input.replyToMessageId ?? null,
+        input.jobId ?? null,
+        status,
+        createdAt,
+        processedAt,
+      ],
+    );
+
+    return {
+      id,
+      telegramUpdateId: null,
+      telegramMessageId: input.telegramMessageId ?? null,
+      chatId: input.chatId,
+      userId: input.userId,
+      direction: 'outgoing',
+      messageType: input.messageType,
+      contentText: input.contentText ?? null,
+      fileId: null,
+      fileUrl: null,
+      fileName: null,
+      mimeType: null,
+      replyToMessageId: input.replyToMessageId ?? null,
+      jobId: input.jobId ?? null,
+      status,
+      errorMessage: null,
+      createdAt,
+      processedAt,
+    };
+  }
+
+  async markMessageProcessing(
+    messageId: string,
+    status: PersistedMessageStatus,
+    errorMessage?: string,
+    jobId?: string,
+  ): Promise<void> {
+    const processedAt = status === 'processed' || status === 'failed' ? nowIso() : null;
+
+    await this.database.run(
+      `UPDATE messages
+       SET status = ?, error_message = ?, processed_at = COALESCE(?, processed_at), job_id = COALESCE(?, job_id)
+       WHERE id = ?`,
+      [status, errorMessage ?? null, processedAt, jobId ?? null, messageId],
+    );
+  }
+
+  async listRecentMessagesByUser(userId: string, limit: number): Promise<PersistedMessage[]> {
+    const rows = await this.database.all<MessageRow>(
+      `SELECT * FROM messages WHERE user_id = ? ORDER BY created_at DESC LIMIT ?`,
+      [userId, limit],
+    );
+
+    return rows.map((row) => this.mapRow(row));
+  }
+
+  async findByTelegramUpdateId(updateId: number): Promise<PersistedMessage | null> {
+    const row = await this.database.get<MessageRow>(
+      `SELECT * FROM messages WHERE telegram_update_id = ? ORDER BY created_at DESC LIMIT 1`,
+      [updateId],
+    );
+
+    return row ? this.mapRow(row) : null;
+  }
+
+  private mapRow(row: MessageRow): PersistedMessage {
+    return {
+      id: row.id,
+      telegramUpdateId: row.telegram_update_id,
+      telegramMessageId: row.telegram_message_id,
+      chatId: row.chat_id,
+      userId: row.user_id,
+      direction: row.direction,
+      messageType: row.message_type,
+      contentText: row.content_text,
+      fileId: row.file_id,
+      fileUrl: row.file_url,
+      fileName: row.file_name,
+      mimeType: row.mime_type,
+      replyToMessageId: row.reply_to_message_id,
+      jobId: row.job_id,
+      status: row.status,
+      errorMessage: row.error_message,
+      createdAt: row.created_at,
+      processedAt: row.processed_at,
+    };
+  }
+}

--- a/src/services/persistence/repositories/pending-clarification.repository.ts
+++ b/src/services/persistence/repositories/pending-clarification.repository.ts
@@ -1,0 +1,119 @@
+import { DatabaseService } from '../database.service';
+import { CreatePendingClarificationInput, PendingClarificationRecord } from '../types';
+import { generateId, nowIso, parseJsonObject, stringifyJson } from '../utils';
+
+interface PendingClarificationRow {
+  id: string;
+  user_id: string;
+  chat_id: string;
+  source_message_id: string | null;
+  job_id: string | null;
+  status: PendingClarificationRecord['status'];
+  intent_name: string | null;
+  confidence_score: number | null;
+  question_text: string;
+  proposed_action_json: string | null;
+  answer_message_id: string | null;
+  expires_at: string | null;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+export class PendingClarificationRepository {
+  constructor(private readonly database: DatabaseService) {}
+
+  async createPendingClarification(
+    input: CreatePendingClarificationInput,
+  ): Promise<PendingClarificationRecord> {
+    const id = generateId('clarification');
+    const createdAt = nowIso();
+
+    await this.database.run(
+      `INSERT INTO pending_clarifications (
+        id, user_id, chat_id, source_message_id, job_id, status, intent_name, confidence_score,
+        question_text, proposed_action_json, answer_message_id, expires_at, created_at, resolved_at
+      ) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, NULL, ?, ?, NULL)`,
+      [
+        id,
+        input.userId,
+        input.chatId,
+        input.sourceMessageId ?? null,
+        input.jobId ?? null,
+        input.intentName ?? null,
+        input.confidenceScore ?? null,
+        input.questionText,
+        stringifyJson(input.proposedAction),
+        input.expiresAt ?? null,
+        createdAt,
+      ],
+    );
+
+    return {
+      id,
+      userId: input.userId,
+      chatId: input.chatId,
+      sourceMessageId: input.sourceMessageId ?? null,
+      jobId: input.jobId ?? null,
+      status: 'pending',
+      intentName: input.intentName ?? null,
+      confidenceScore: input.confidenceScore ?? null,
+      questionText: input.questionText,
+      proposedAction: input.proposedAction ?? null,
+      answerMessageId: null,
+      expiresAt: input.expiresAt ?? null,
+      createdAt,
+      resolvedAt: null,
+    };
+  }
+
+  async findActiveByUser(userId: string): Promise<PendingClarificationRecord | null> {
+    const row = await this.database.get<PendingClarificationRow>(
+      `SELECT * FROM pending_clarifications WHERE user_id = ? AND status = 'pending' ORDER BY created_at DESC LIMIT 1`,
+      [userId],
+    );
+
+    return row ? this.mapRow(row) : null;
+  }
+
+  async resolveClarification(
+    clarificationId: string,
+    status: 'answered' | 'expired' | 'cancelled',
+    answerMessageId?: string,
+  ): Promise<void> {
+    await this.database.run(
+      `UPDATE pending_clarifications
+       SET status = ?, answer_message_id = COALESCE(?, answer_message_id), resolved_at = ?
+       WHERE id = ?`,
+      [status, answerMessageId ?? null, nowIso(), clarificationId],
+    );
+  }
+
+  async expireClarifications(now: string): Promise<number> {
+    const result = await this.database.run(
+      `UPDATE pending_clarifications
+       SET status = 'expired', resolved_at = ?
+       WHERE status = 'pending' AND expires_at IS NOT NULL AND expires_at <= ?`,
+      [now, now],
+    );
+    return result.changes;
+  }
+
+  private mapRow(row: PendingClarificationRow): PendingClarificationRecord {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      chatId: row.chat_id,
+      sourceMessageId: row.source_message_id,
+      jobId: row.job_id,
+      status: row.status,
+      intentName: row.intent_name,
+      confidenceScore: row.confidence_score,
+      questionText: row.question_text,
+      proposedAction: parseJsonObject(row.proposed_action_json),
+      answerMessageId: row.answer_message_id,
+      expiresAt: row.expires_at,
+      createdAt: row.created_at,
+      resolvedAt: row.resolved_at,
+    };
+  }
+}

--- a/src/services/persistence/repositories/usage-event.repository.ts
+++ b/src/services/persistence/repositories/usage-event.repository.ts
@@ -1,0 +1,120 @@
+import { DatabaseService } from '../database.service';
+import { RecordUsageEventInput, UsageEventRecord, UsageSummary } from '../types';
+import { generateId, nowIso, parseJsonObject, stringifyJson } from '../utils';
+
+interface UsageEventRow {
+  id: string;
+  user_id: string | null;
+  chat_id: string | null;
+  job_id: string | null;
+  message_id: string | null;
+  event_type: UsageEventRecord['eventType'];
+  model: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  estimated_cost_usd: number | null;
+  duration_ms: number | null;
+  metadata_json: string | null;
+  created_at: string;
+}
+
+interface UsageSummaryRow {
+  event_count: number | null;
+  total_input_tokens: number | null;
+  total_output_tokens: number | null;
+  total_estimated_cost_usd: number | null;
+}
+
+export class UsageEventRepository {
+  constructor(private readonly database: DatabaseService) {}
+
+  async recordEvent(input: RecordUsageEventInput): Promise<UsageEventRecord> {
+    const id = generateId('usage');
+    const createdAt = nowIso();
+
+    await this.database.run(
+      `INSERT INTO usage_events (
+        id, user_id, chat_id, job_id, message_id, event_type, model, input_tokens,
+        output_tokens, estimated_cost_usd, duration_ms, metadata_json, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        input.userId ?? null,
+        input.chatId ?? null,
+        input.jobId ?? null,
+        input.messageId ?? null,
+        input.eventType,
+        input.model ?? null,
+        input.inputTokens ?? null,
+        input.outputTokens ?? null,
+        input.estimatedCostUsd ?? null,
+        input.durationMs ?? null,
+        stringifyJson(input.metadata),
+        createdAt,
+      ],
+    );
+
+    return {
+      id,
+      userId: input.userId ?? null,
+      chatId: input.chatId ?? null,
+      jobId: input.jobId ?? null,
+      messageId: input.messageId ?? null,
+      eventType: input.eventType,
+      model: input.model ?? null,
+      inputTokens: input.inputTokens ?? null,
+      outputTokens: input.outputTokens ?? null,
+      estimatedCostUsd: input.estimatedCostUsd ?? null,
+      durationMs: input.durationMs ?? null,
+      metadata: input.metadata ?? null,
+      createdAt,
+    };
+  }
+
+  async listEventsForUser(userId: string, limit: number): Promise<UsageEventRecord[]> {
+    const rows = await this.database.all<UsageEventRow>(
+      `SELECT * FROM usage_events WHERE user_id = ? ORDER BY created_at DESC LIMIT ?`,
+      [userId, limit],
+    );
+
+    return rows.map((row) => this.mapRow(row));
+  }
+
+  async summarizeUsageForUser(userId: string, createdAfter: string): Promise<UsageSummary> {
+    const row = await this.database.get<UsageSummaryRow>(
+      `SELECT
+         COUNT(*) AS event_count,
+         COALESCE(SUM(input_tokens), 0) AS total_input_tokens,
+         COALESCE(SUM(output_tokens), 0) AS total_output_tokens,
+         COALESCE(SUM(estimated_cost_usd), 0) AS total_estimated_cost_usd
+       FROM usage_events
+       WHERE user_id = ? AND created_at >= ?`,
+      [userId, createdAfter],
+    );
+
+    return {
+      eventCount: row?.event_count || 0,
+      totalInputTokens: row?.total_input_tokens || 0,
+      totalOutputTokens: row?.total_output_tokens || 0,
+      totalEstimatedCostUsd: row?.total_estimated_cost_usd || 0,
+    };
+  }
+
+  private mapRow(row: UsageEventRow): UsageEventRecord {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      chatId: row.chat_id,
+      jobId: row.job_id,
+      messageId: row.message_id,
+      eventType: row.event_type,
+      model: row.model,
+      inputTokens: row.input_tokens,
+      outputTokens: row.output_tokens,
+      estimatedCostUsd: row.estimated_cost_usd,
+      durationMs: row.duration_ms,
+      metadata: parseJsonObject(row.metadata_json),
+      createdAt: row.created_at,
+    };
+  }
+}

--- a/src/services/persistence/repositories/user-preferences.repository.ts
+++ b/src/services/persistence/repositories/user-preferences.repository.ts
@@ -1,0 +1,74 @@
+import { DatabaseService } from '../database.service';
+import { UserPreferenceRecord } from '../types';
+import { generateId, nowIso, parseJsonObject } from '../utils';
+
+interface UserPreferenceRow {
+  id: string;
+  user_id: string;
+  preference_key: string;
+  preference_value_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export class UserPreferencesRepository {
+  constructor(private readonly database: DatabaseService) {}
+
+  async getPreference(userId: string, key: string): Promise<UserPreferenceRecord | null> {
+    const row = await this.database.get<UserPreferenceRow>(
+      `SELECT * FROM user_preferences WHERE user_id = ? AND preference_key = ?`,
+      [userId, key],
+    );
+
+    return row ? this.mapRow(row) : null;
+  }
+
+  async setPreference(
+    userId: string,
+    key: string,
+    value: Record<string, unknown>,
+  ): Promise<UserPreferenceRecord> {
+    const existing = await this.getPreference(userId, key);
+    const now = nowIso();
+    const id = existing?.id || generateId('pref');
+
+    await this.database.run(
+      `INSERT INTO user_preferences (
+        id, user_id, preference_key, preference_value_json, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(user_id, preference_key) DO UPDATE SET
+        preference_value_json = excluded.preference_value_json,
+        updated_at = excluded.updated_at`,
+      [id, userId, key, JSON.stringify(value), existing?.createdAt || now, now],
+    );
+
+    return {
+      id,
+      userId,
+      preferenceKey: key,
+      preferenceValue: value,
+      createdAt: existing?.createdAt || now,
+      updatedAt: now,
+    };
+  }
+
+  async listPreferences(userId: string): Promise<UserPreferenceRecord[]> {
+    const rows = await this.database.all<UserPreferenceRow>(
+      `SELECT * FROM user_preferences WHERE user_id = ? ORDER BY preference_key ASC`,
+      [userId],
+    );
+
+    return rows.map((row) => this.mapRow(row));
+  }
+
+  private mapRow(row: UserPreferenceRow): UserPreferenceRecord {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      preferenceKey: row.preference_key,
+      preferenceValue: parseJsonObject(row.preference_value_json) || {},
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+}

--- a/src/services/persistence/types.ts
+++ b/src/services/persistence/types.ts
@@ -1,0 +1,187 @@
+export interface DatabaseConfig {
+  path: string;
+  verboseLogging: boolean;
+}
+
+export type MessageDirection = 'incoming' | 'outgoing' | 'system';
+export type PersistedMessageType =
+  | 'text'
+  | 'voice'
+  | 'audio'
+  | 'audio_document'
+  | 'command'
+  | 'status'
+  | 'error';
+export type PersistedMessageStatus = 'received' | 'processing' | 'processed' | 'failed';
+
+export type JobType =
+  | 'text_processing'
+  | 'voice_processing'
+  | 'audio_document_processing'
+  | 'tool_execution';
+export type JobStatus =
+  | 'queued'
+  | 'in_progress'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'superseded';
+
+export type ClarificationStatus = 'pending' | 'answered' | 'expired' | 'cancelled';
+
+export type UsageEventType =
+  | 'message_received'
+  | 'message_processed'
+  | 'gpt_request'
+  | 'gpt_response'
+  | 'tool_called'
+  | 'tool_completed'
+  | 'audio_transcription'
+  | 'error';
+
+export interface PersistedMessage {
+  id: string;
+  telegramUpdateId: number | null;
+  telegramMessageId: number | null;
+  chatId: string;
+  userId: string;
+  direction: MessageDirection;
+  messageType: PersistedMessageType;
+  contentText: string | null;
+  fileId: string | null;
+  fileUrl: string | null;
+  fileName: string | null;
+  mimeType: string | null;
+  replyToMessageId: string | null;
+  jobId: string | null;
+  status: PersistedMessageStatus;
+  errorMessage: string | null;
+  createdAt: string;
+  processedAt: string | null;
+}
+
+export interface PersistedJob {
+  id: string;
+  userId: string;
+  chatId: string;
+  sourceMessageId: string | null;
+  jobType: JobType;
+  status: JobStatus;
+  payload: Record<string, unknown>;
+  result: Record<string, unknown> | null;
+  errorMessage: string | null;
+  attemptCount: number;
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PendingClarificationRecord {
+  id: string;
+  userId: string;
+  chatId: string;
+  sourceMessageId: string | null;
+  jobId: string | null;
+  status: ClarificationStatus;
+  intentName: string | null;
+  confidenceScore: number | null;
+  questionText: string;
+  proposedAction: Record<string, unknown> | null;
+  answerMessageId: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+  resolvedAt: string | null;
+}
+
+export interface UserPreferenceRecord {
+  id: string;
+  userId: string;
+  preferenceKey: string;
+  preferenceValue: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UsageEventRecord {
+  id: string;
+  userId: string | null;
+  chatId: string | null;
+  jobId: string | null;
+  messageId: string | null;
+  eventType: UsageEventType;
+  model: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  estimatedCostUsd: number | null;
+  durationMs: number | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface CreateIncomingMessageInput {
+  telegramUpdateId?: number;
+  telegramMessageId?: number;
+  chatId: string;
+  userId: string;
+  messageType: PersistedMessageType;
+  contentText?: string;
+  fileId?: string;
+  fileUrl?: string;
+  fileName?: string;
+  mimeType?: string;
+  jobId?: string;
+  status?: PersistedMessageStatus;
+}
+
+export interface CreateOutgoingMessageInput {
+  telegramMessageId?: number;
+  chatId: string;
+  userId: string;
+  messageType: PersistedMessageType;
+  contentText?: string;
+  replyToMessageId?: string;
+  jobId?: string;
+  status?: PersistedMessageStatus;
+}
+
+export interface CreateJobInput {
+  userId: string;
+  chatId: string;
+  sourceMessageId?: string;
+  jobType: JobType;
+  payload: Record<string, unknown>;
+}
+
+export interface CreatePendingClarificationInput {
+  userId: string;
+  chatId: string;
+  sourceMessageId?: string;
+  jobId?: string;
+  intentName?: string;
+  confidenceScore?: number;
+  questionText: string;
+  proposedAction?: Record<string, unknown>;
+  expiresAt?: string;
+}
+
+export interface RecordUsageEventInput {
+  userId?: string;
+  chatId?: string;
+  jobId?: string;
+  messageId?: string;
+  eventType: UsageEventType;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  estimatedCostUsd?: number;
+  durationMs?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UsageSummary {
+  eventCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalEstimatedCostUsd: number;
+}

--- a/src/services/persistence/usage-tracking.service.ts
+++ b/src/services/persistence/usage-tracking.service.ts
@@ -1,0 +1,18 @@
+import { UsageEventRepository } from './repositories/usage-event.repository';
+import { RecordUsageEventInput, UsageEventRecord, UsageSummary } from './types';
+
+export class UsageTrackingService {
+  constructor(private readonly usageEventRepository: UsageEventRepository) {}
+
+  recordEvent(input: RecordUsageEventInput): Promise<UsageEventRecord> {
+    return this.usageEventRepository.recordEvent(input);
+  }
+
+  listEventsForUser(userId: string, limit: number): Promise<UsageEventRecord[]> {
+    return this.usageEventRepository.listEventsForUser(userId, limit);
+  }
+
+  summarizeUsageForUser(userId: string, createdAfter: string): Promise<UsageSummary> {
+    return this.usageEventRepository.summarizeUsageForUser(userId, createdAfter);
+  }
+}

--- a/src/services/persistence/utils.ts
+++ b/src/services/persistence/utils.ts
@@ -1,0 +1,25 @@
+import crypto from 'crypto';
+
+export function generateId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function parseJsonObject(value: string | null): Record<string, unknown> | null {
+  if (!value) {
+    return null;
+  }
+
+  return JSON.parse(value) as Record<string, unknown>;
+}
+
+export function stringifyJson(value: Record<string, unknown> | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return JSON.stringify(value);
+}

--- a/src/services/telegram/handlers/command-handlers.ts
+++ b/src/services/telegram/handlers/command-handlers.ts
@@ -3,6 +3,8 @@ import { Context } from 'telegraf';
 import { logger } from '../../../utils/logger';
 import { BotActivityService } from '../bot-activity.service';
 import { BotStatusService } from '../bot-status.service';
+import { ConversationStoreService } from '../../persistence';
+import { Message } from 'telegraf/typings/core/types/typegram';
 
 /**
  * Handles bot commands
@@ -11,12 +13,28 @@ export class CommandHandlers {
   constructor(
     private readonly activityService: BotActivityService,
     private readonly statusService: BotStatusService,
+    private readonly conversationStore?: ConversationStoreService,
   ) {}
 
   async handleHelp(ctx: Context): Promise<void> {
     const userId = ctx.from?.id;
+    const chatId = ctx.chat?.id;
+    const updateId = ctx.update && 'update_id' in ctx.update ? ctx.update.update_id : undefined;
+    const telegramMessageId = ctx.message && 'message_id' in ctx.message ? ctx.message.message_id : undefined;
     logger.info('User requested help', { userId });
     this.activityService.recordActivity('command_help');
+
+    const incomingMessage = userId && chatId
+      ? await this.conversationStore?.createIncomingMessage({
+          telegramUpdateId: updateId,
+          telegramMessageId,
+          chatId: chatId.toString(),
+          userId: userId.toString(),
+          messageType: 'command',
+          contentText: '/help',
+          status: 'processed',
+        })
+      : null;
 
     const helpMessage = `🆘 *JarvisMCP Help*
 
@@ -35,15 +53,52 @@ export class CommandHandlers {
 • WAV
 • M4A`;
 
-    await ctx.reply(helpMessage, { parse_mode: 'Markdown' });
+    const reply = (await ctx.reply(helpMessage, { parse_mode: 'Markdown' })) as Message.TextMessage;
+    if (userId && chatId) {
+      await this.conversationStore?.createOutgoingMessage({
+        telegramMessageId: reply.message_id,
+        chatId: chatId.toString(),
+        userId: userId.toString(),
+        messageType: 'command',
+        contentText: helpMessage,
+        replyToMessageId: incomingMessage?.id,
+        status: 'processed',
+      });
+    }
   }
 
   async handleStatus(ctx: Context): Promise<void> {
     const userId = ctx.from?.id;
+    const chatId = ctx.chat?.id;
+    const updateId = ctx.update && 'update_id' in ctx.update ? ctx.update.update_id : undefined;
+    const telegramMessageId = ctx.message && 'message_id' in ctx.message ? ctx.message.message_id : undefined;
     logger.info('User requested status', { userId });
     this.activityService.recordActivity('command_status');
 
+    const incomingMessage = userId && chatId
+      ? await this.conversationStore?.createIncomingMessage({
+          telegramUpdateId: updateId,
+          telegramMessageId,
+          chatId: chatId.toString(),
+          userId: userId.toString(),
+          messageType: 'command',
+          contentText: '/status',
+          status: 'processed',
+        })
+      : null;
+
     const statusMessage = await this.statusService.getFormattedStatus();
-    await ctx.reply(statusMessage, { parse_mode: 'Markdown' });
+    const reply = (await ctx.reply(statusMessage, { parse_mode: 'Markdown' })) as Message.TextMessage;
+    if (userId && chatId) {
+      await this.conversationStore?.createOutgoingMessage({
+        telegramMessageId: reply.message_id,
+        chatId: chatId.toString(),
+        userId: userId.toString(),
+        messageType: 'status',
+        contentText: statusMessage,
+        replyToMessageId: incomingMessage?.id,
+        status: 'processed',
+      });
+    }
   }
 }

--- a/src/services/telegram/handlers/message-handlers.ts
+++ b/src/services/telegram/handlers/message-handlers.ts
@@ -4,6 +4,9 @@ import { logger } from '../../../utils/logger';
 import { FileService } from '../file.service';
 import { MessageProcessorService } from '../message-processor.service';
 import { BotActivityService } from '../bot-activity.service';
+import { ConversationStoreService, JobStateService, UsageTrackingService } from '../../persistence';
+import { Message } from 'telegraf/typings/core/types/typegram';
+import { ProcessorResponse } from '../../../types/processing.types';
 
 /**
  * Handles different types of messages
@@ -13,6 +16,9 @@ export class MessageHandlers {
     private readonly fileService: FileService,
     private readonly messageProcessor: MessageProcessorService,
     private readonly activityService: BotActivityService,
+    private readonly conversationStore?: ConversationStoreService,
+    private readonly jobStateService?: JobStateService,
+    private readonly usageTrackingService?: UsageTrackingService,
   ) {}
 
   async handleText(ctx: Context): Promise<void> {
@@ -20,6 +26,10 @@ export class MessageHandlers {
 
     const messageText = ctx.message.text;
     const userId = ctx.from?.id;
+    const chatId = ctx.chat?.id;
+    const updateId = ctx.update && 'update_id' in ctx.update ? ctx.update.update_id : undefined;
+    let inboundMessageId: string | undefined;
+    let jobId: string | undefined;
 
     logger.info('Received text message', {
       userId,
@@ -29,14 +39,70 @@ export class MessageHandlers {
     this.activityService.recordActivity('message_text');
 
     try {
-      const response = await this.messageProcessor.processTextMessage(messageText, userId);
-      await ctx.reply(response);
+      const inboundMessage = userId && chatId
+        ? await this.conversationStore?.createIncomingMessage({
+            telegramUpdateId: updateId,
+            telegramMessageId: ctx.message.message_id,
+            chatId: chatId.toString(),
+            userId: userId.toString(),
+            messageType: 'text',
+            contentText: messageText,
+          })
+        : null;
+      inboundMessageId = inboundMessage?.id;
+      const job = userId && chatId
+        ? await this.jobStateService?.createJob({
+            userId: userId.toString(),
+            chatId: chatId.toString(),
+            sourceMessageId: inboundMessage?.id,
+            jobType: 'text_processing',
+            payload: {
+              messageType: 'text',
+              input: {
+                text: messageText,
+              },
+              telegram: {
+                updateId: updateId ?? null,
+                messageId: ctx.message.message_id,
+              },
+            },
+          })
+        : null;
+      jobId = job?.id;
+
+      if (inboundMessage) {
+        await this.conversationStore?.markMessageProcessing(inboundMessage.id, 'processing', undefined, job?.id);
+      }
+      if (job) {
+        await this.jobStateService?.markInProgress(job.id);
+      }
+
+      const response = await this.messageProcessor.processTextMessageDetailed(messageText, userId, {
+        jobId,
+        sourceMessageId: inboundMessageId,
+        chatId: chatId?.toString(),
+      });
+      await this.replyAndPersist(ctx, response, {
+        inboundMessageId,
+        jobId,
+        userId,
+        chatId,
+        outgoingType: 'text',
+      });
     } catch (error) {
       logger.error('Error processing text message', {
         error: (error as Error).message,
         userId
       });
-      await ctx.reply('❌ Sorry, I had trouble processing your message.');
+      await this.replyWithFailure(ctx, {
+        userId,
+        chatId,
+        inboundMessageId,
+        jobId,
+        outgoingType: 'error',
+        fallbackText: '❌ Sorry, I had trouble processing your message.',
+        inboundType: 'text',
+      }, error as Error);
     }
   }
 
@@ -45,6 +111,10 @@ export class MessageHandlers {
 
     const voice = ctx.message.voice;
     const userId = ctx.from?.id;
+    const chatId = ctx.chat?.id;
+    const updateId = ctx.update && 'update_id' in ctx.update ? ctx.update.update_id : undefined;
+    let inboundMessageId: string | undefined;
+    let jobId: string | undefined;
 
     logger.info('Voice message received', {
       userId,
@@ -55,14 +125,75 @@ export class MessageHandlers {
 
     try {
       const fileUrl = await this.fileService.getFileUrl(voice.file_id);
-      const response = await this.messageProcessor.processAudioMessage(fileUrl, userId);
-      await ctx.reply(response);
+      const inboundMessage = userId && chatId
+        ? await this.conversationStore?.createIncomingMessage({
+            telegramUpdateId: updateId,
+            telegramMessageId: ctx.message.message_id,
+            chatId: chatId.toString(),
+            userId: userId.toString(),
+            messageType: 'voice',
+            fileId: voice.file_id,
+            fileUrl,
+            mimeType: 'audio/ogg',
+          })
+        : null;
+      inboundMessageId = inboundMessage?.id;
+      const job = userId && chatId
+        ? await this.jobStateService?.createJob({
+            userId: userId.toString(),
+            chatId: chatId.toString(),
+            sourceMessageId: inboundMessage?.id,
+            jobType: 'voice_processing',
+            payload: {
+              messageType: 'voice',
+              input: {
+                text: null,
+                fileUrl,
+                fileName: null,
+                mimeType: 'audio/ogg',
+              },
+              telegram: {
+                updateId: updateId ?? null,
+                messageId: ctx.message.message_id,
+              },
+            },
+          })
+        : null;
+      jobId = job?.id;
+
+      if (inboundMessage) {
+        await this.conversationStore?.markMessageProcessing(inboundMessage.id, 'processing', undefined, job?.id);
+      }
+      if (job) {
+        await this.jobStateService?.markInProgress(job.id);
+      }
+
+      const response = await this.messageProcessor.processAudioMessageDetailed(fileUrl, userId, {
+        jobId,
+        sourceMessageId: inboundMessageId,
+        chatId: chatId?.toString(),
+      });
+      await this.replyAndPersist(ctx, response, {
+        inboundMessageId,
+        jobId,
+        userId,
+        chatId,
+        outgoingType: 'audio',
+      });
     } catch (error) {
       logger.error('Error processing voice message', {
         error: (error as Error).message,
         userId
       });
-      await ctx.reply('❌ Sorry, I had trouble processing your voice message.');
+      await this.replyWithFailure(ctx, {
+        userId,
+        chatId,
+        inboundMessageId,
+        jobId,
+        outgoingType: 'error',
+        fallbackText: '❌ Sorry, I had trouble processing your voice message.',
+        inboundType: 'voice',
+      }, error as Error);
     }
   }
 
@@ -84,6 +215,10 @@ export class MessageHandlers {
       this.activityService.recordActivity('message_document');
       const fileName = document.file_name || 'audio_file';
       const mimeType = document.mime_type || 'application/octet-stream';
+      const chatId = ctx.chat?.id;
+      const updateId = ctx.update && 'update_id' in ctx.update ? ctx.update.update_id : undefined;
+      let inboundMessageId: string | undefined;
+      let jobId: string | undefined;
 
       logger.info('Audio document received', {
         userId,
@@ -94,20 +229,83 @@ export class MessageHandlers {
 
       try {
         const fileUrl = await this.fileService.getFileUrl(document.file_id);
-        const response = await this.messageProcessor.processAudioDocument(
+        const inboundMessage = userId && chatId
+          ? await this.conversationStore?.createIncomingMessage({
+              telegramUpdateId: updateId,
+              telegramMessageId: ctx.message.message_id,
+              chatId: chatId.toString(),
+              userId: userId.toString(),
+              messageType: 'audio_document',
+              fileId: document.file_id,
+              fileUrl,
+              fileName,
+              mimeType,
+            })
+          : null;
+        inboundMessageId = inboundMessage?.id;
+        const job = userId && chatId
+          ? await this.jobStateService?.createJob({
+              userId: userId.toString(),
+              chatId: chatId.toString(),
+              sourceMessageId: inboundMessage?.id,
+              jobType: 'audio_document_processing',
+              payload: {
+                messageType: 'audio_document',
+                input: {
+                  text: null,
+                  fileUrl,
+                  fileName,
+                  mimeType,
+                },
+                telegram: {
+                  updateId: updateId ?? null,
+                  messageId: ctx.message.message_id,
+                },
+              },
+            })
+          : null;
+        jobId = job?.id;
+
+        if (inboundMessage) {
+          await this.conversationStore?.markMessageProcessing(inboundMessage.id, 'processing', undefined, job?.id);
+        }
+        if (job) {
+          await this.jobStateService?.markInProgress(job.id);
+        }
+
+        const response = await this.messageProcessor.processAudioDocumentDetailed(
           fileUrl,
           fileName,
           mimeType,
           userId,
+          {
+            jobId,
+            sourceMessageId: inboundMessageId,
+            chatId: chatId?.toString(),
+          },
         );
-        await ctx.reply(response);
+        await this.replyAndPersist(ctx, response, {
+          inboundMessageId,
+          jobId,
+          userId,
+          chatId,
+          outgoingType: 'audio_document',
+        });
       } catch (error) {
         logger.error('Error processing audio document', {
           error: (error as Error).message,
           userId,
           fileName,
         });
-        await ctx.reply('❌ Sorry, I had trouble processing your audio document.');
+        await this.replyWithFailure(ctx, {
+          userId,
+          chatId: ctx.chat?.id,
+          inboundMessageId,
+          jobId,
+          outgoingType: 'error',
+          fallbackText: '❌ Sorry, I had trouble processing your audio document.',
+          inboundType: 'audio_document',
+        }, error as Error);
       }
     } else {
       logger.info('Non-audio document received', {
@@ -135,8 +333,12 @@ export class MessageHandlers {
 
   private async processAudioFile(ctx: Context, audioFile: any): Promise<void> {
     const userId = ctx.from?.id;
+    const chatId = ctx.chat?.id;
+    const updateId = ctx.update && 'update_id' in ctx.update ? ctx.update.update_id : undefined;
     const fileName = audioFile.file_name || 'audio_file';
     const mimeType = audioFile.mime_type;
+    let inboundMessageId: string | undefined;
+    let jobId: string | undefined;
 
     logger.info('Audio file received', {
       userId,
@@ -148,15 +350,179 @@ export class MessageHandlers {
 
     try {
       const fileUrl = await this.fileService.getFileUrl(audioFile.file_id);
-      const response = await this.messageProcessor.processAudioMessage(fileUrl, userId);
-      await ctx.reply(response);
+      const inboundMessage = userId && chatId
+        ? await this.conversationStore?.createIncomingMessage({
+            telegramUpdateId: updateId,
+            telegramMessageId: ctx.message && 'message_id' in ctx.message ? ctx.message.message_id : undefined,
+            chatId: chatId.toString(),
+            userId: userId.toString(),
+            messageType: 'audio',
+            fileId: audioFile.file_id,
+            fileUrl,
+            fileName,
+            mimeType,
+          })
+        : null;
+      inboundMessageId = inboundMessage?.id;
+      const job = userId && chatId
+        ? await this.jobStateService?.createJob({
+            userId: userId.toString(),
+            chatId: chatId.toString(),
+            sourceMessageId: inboundMessage?.id,
+            jobType: 'voice_processing',
+            payload: {
+              messageType: 'audio',
+              input: {
+                text: null,
+                fileUrl,
+                fileName,
+                mimeType,
+              },
+              telegram: {
+                updateId: updateId ?? null,
+                messageId: ctx.message && 'message_id' in ctx.message ? ctx.message.message_id : null,
+              },
+            },
+          })
+        : null;
+      jobId = job?.id;
+
+      if (inboundMessage) {
+        await this.conversationStore?.markMessageProcessing(inboundMessage.id, 'processing', undefined, job?.id);
+      }
+      if (job) {
+        await this.jobStateService?.markInProgress(job.id);
+      }
+
+      const response = await this.messageProcessor.processAudioMessageDetailed(fileUrl, userId, {
+        jobId,
+        sourceMessageId: inboundMessageId,
+        chatId: chatId?.toString(),
+      });
+      await this.replyAndPersist(ctx, response, {
+        inboundMessageId,
+        jobId,
+        userId,
+        chatId,
+        outgoingType: 'audio',
+      });
     } catch (error) {
       logger.error('Error processing audio file', {
         error: (error as Error).message,
         userId,
         fileName
       });
-      await ctx.reply('❌ Sorry, I had trouble processing your audio file.');
+      await this.replyWithFailure(ctx, {
+        userId,
+        chatId,
+        inboundMessageId,
+        jobId,
+        outgoingType: 'error',
+        fallbackText: '❌ Sorry, I had trouble processing your audio file.',
+        inboundType: 'audio',
+      }, error as Error);
+    }
+  }
+
+  private async replyAndPersist(
+    ctx: Context,
+    response: ProcessorResponse,
+    details: {
+      inboundMessageId?: string;
+      jobId?: string;
+      userId?: number;
+      chatId?: number;
+      outgoingType: 'text' | 'audio' | 'audio_document';
+    },
+  ): Promise<void> {
+    const reply = (await ctx.reply(response.responseText)) as Message.TextMessage;
+
+    if (details.inboundMessageId) {
+      await this.conversationStore?.markMessageProcessing(details.inboundMessageId, 'processed');
+    }
+    if (details.jobId) {
+      await this.jobStateService?.markCompleted(details.jobId, {
+        responseText: response.responseText,
+        processingTimeMs: response.processingTimeMs ?? null,
+        transcriptionText: response.transcriptionText ?? null,
+      });
+    }
+    if (details.userId && details.chatId) {
+      await this.conversationStore?.createOutgoingMessage({
+        telegramMessageId: reply.message_id,
+        chatId: details.chatId.toString(),
+        userId: details.userId.toString(),
+        messageType: details.outgoingType,
+        contentText: response.responseText,
+        replyToMessageId: details.inboundMessageId,
+        jobId: details.jobId,
+      });
+      await this.usageTrackingService?.recordEvent({
+        userId: details.userId.toString(),
+        chatId: details.chatId.toString(),
+        jobId: details.jobId,
+        messageId: details.inboundMessageId,
+        eventType: 'message_processed',
+        durationMs: response.processingTimeMs,
+        metadata: {
+          responseLength: response.responseText.length,
+          messageType: details.outgoingType,
+        },
+      });
+    }
+  }
+
+  private async replyWithFailure(
+    ctx: Context,
+    details: {
+      userId?: number;
+      chatId?: number;
+      inboundMessageId?: string;
+      jobId?: string;
+      outgoingType: 'error';
+      fallbackText: string;
+      inboundType: string;
+    },
+    error: Error,
+  ): Promise<void> {
+    const reply = (await ctx.reply(details.fallbackText)) as Message.TextMessage;
+
+    if (details.inboundMessageId) {
+      await this.conversationStore?.markMessageProcessing(
+        details.inboundMessageId,
+        'failed',
+        error.message,
+        details.jobId,
+      );
+    }
+    if (details.jobId) {
+      await this.jobStateService?.markFailed(details.jobId, error.message, {
+        responseText: details.fallbackText,
+      });
+    }
+    if (details.userId && details.chatId) {
+      await this.conversationStore?.createOutgoingMessage({
+        telegramMessageId: reply.message_id,
+        chatId: details.chatId.toString(),
+        userId: details.userId.toString(),
+        messageType: details.outgoingType,
+        contentText: details.fallbackText,
+        status: 'processed',
+        replyToMessageId: details.inboundMessageId,
+        jobId: details.jobId,
+      });
+      await this.usageTrackingService?.recordEvent({
+        userId: details.userId.toString(),
+        chatId: details.chatId.toString(),
+        jobId: details.jobId,
+        messageId: details.inboundMessageId,
+        eventType: 'error',
+        metadata: {
+          source: 'telegram_handler',
+          inboundType: details.inboundType,
+          error: error.message,
+        },
+      });
     }
   }
 }

--- a/src/services/telegram/handlers/telegram-handlers.ts
+++ b/src/services/telegram/handlers/telegram-handlers.ts
@@ -6,6 +6,7 @@ import { CommandHandlers } from '../handlers/command-handlers';
 import { MessageHandlers } from '../handlers/message-handlers';
 import { BotActivityService } from '../bot-activity.service';
 import { BotStatusService } from '../bot-status.service';
+import { ConversationStoreService, JobStateService, UsageTrackingService } from '../../persistence';
 
 /**
  * Centralizes all Telegram bot handlers
@@ -19,9 +20,19 @@ export class TelegramHandlers {
     messageProcessor: MessageProcessorService,
     activityService: BotActivityService,
     statusService: BotStatusService,
+    conversationStore?: ConversationStoreService,
+    jobStateService?: JobStateService,
+    usageTrackingService?: UsageTrackingService,
   ) {
-    this.commandHandlers = new CommandHandlers(activityService, statusService);
-    this.messageHandlers = new MessageHandlers(fileService, messageProcessor, activityService);
+    this.commandHandlers = new CommandHandlers(activityService, statusService, conversationStore);
+    this.messageHandlers = new MessageHandlers(
+      fileService,
+      messageProcessor,
+      activityService,
+      conversationStore,
+      jobStateService,
+      usageTrackingService,
+    );
   }
 
   setupHandlers(bot: Telegraf<Context>): void {

--- a/src/services/telegram/message-processor.service.ts
+++ b/src/services/telegram/message-processor.service.ts
@@ -3,6 +3,8 @@ import { logger } from '../../utils/logger';
 import { TextProcessorService } from './processors/text-processor.service';
 import { AudioProcessorService } from './processors/audio-processor.service';
 import { ToolDispatcher } from '../../types/tool.types';
+import { ProcessorResponse, ProcessingContext } from '../../types/processing.types';
+import { UsageTrackingService } from '../persistence';
 
 /**
  * Main service responsible for coordinating message processing
@@ -12,33 +14,57 @@ export class MessageProcessorService {
   private readonly textProcessor: TextProcessorService;
   private readonly audioProcessor: AudioProcessorService;
 
-  constructor(toolDispatcher?: ToolDispatcher) {
-    this.textProcessor = new TextProcessorService(toolDispatcher);
-    this.audioProcessor = new AudioProcessorService();
+  constructor(toolDispatcher?: ToolDispatcher, usageTrackingService?: UsageTrackingService) {
+    this.textProcessor = new TextProcessorService(toolDispatcher, usageTrackingService);
+    this.audioProcessor = new AudioProcessorService(usageTrackingService);
   }
 
   /**
    * Processes text messages from users
    */
-  async processTextMessage(text: string, userId?: number): Promise<string> {
+  async processTextMessage(
+    text: string,
+    userId?: number,
+    context?: ProcessingContext,
+  ): Promise<string> {
     logger.info('Delegating text message processing', {
       userId,
       messageLength: text.length,
     });
 
-    return this.textProcessor.processTextMessage(text, userId);
+    return this.textProcessor.processTextMessage(text, userId, context);
+  }
+
+  async processTextMessageDetailed(
+    text: string,
+    userId?: number,
+    context?: ProcessingContext,
+  ): Promise<ProcessorResponse> {
+    return this.textProcessor.processTextMessageDetailed(text, userId, context);
   }
 
   /**
    * Processes audio messages (voice notes, audio files)
    */
-  async processAudioMessage(fileUrl: string, userId?: number): Promise<string> {
+  async processAudioMessage(
+    fileUrl: string,
+    userId?: number,
+    context?: ProcessingContext,
+  ): Promise<string> {
     logger.info('Delegating audio message processing', {
       userId,
       fileUrl: fileUrl.substring(0, 50) + '...', // Log partial URL for privacy
     });
 
-    return this.audioProcessor.processAudioMessage(fileUrl, userId);
+    return this.audioProcessor.processAudioMessage(fileUrl, userId, context);
+  }
+
+  async processAudioMessageDetailed(
+    fileUrl: string,
+    userId?: number,
+    context?: ProcessingContext,
+  ): Promise<ProcessorResponse> {
+    return this.audioProcessor.processAudioMessageDetailed(fileUrl, userId, context);
   }
 
   /**
@@ -49,6 +75,7 @@ export class MessageProcessorService {
     fileName: string,
     mimeType: string,
     userId?: number,
+    context?: ProcessingContext,
   ): Promise<string> {
     logger.info('Delegating audio document processing', {
       userId,
@@ -56,7 +83,23 @@ export class MessageProcessorService {
       mimeType,
     });
 
-    return this.audioProcessor.processAudioDocument(fileUrl, fileName, mimeType, userId);
+    return this.audioProcessor.processAudioDocument(fileUrl, fileName, mimeType, userId, context);
+  }
+
+  async processAudioDocumentDetailed(
+    fileUrl: string,
+    fileName: string,
+    mimeType: string,
+    userId?: number,
+    context?: ProcessingContext,
+  ): Promise<ProcessorResponse> {
+    return this.audioProcessor.processAudioDocumentDetailed(
+      fileUrl,
+      fileName,
+      mimeType,
+      userId,
+      context,
+    );
   }
 
   /**

--- a/src/services/telegram/processors/audio-processor.service.ts
+++ b/src/services/telegram/processors/audio-processor.service.ts
@@ -2,6 +2,8 @@
 import { logger } from '../../../utils/logger';
 import { WhisperService } from '../../ai/whisper.service';
 import { GPTService } from '../../ai/gpt.service';
+import { ProcessorResponse, ProcessingContext } from '../../../types/processing.types';
+import { UsageTrackingService } from '../../persistence';
 
 /**
  * Service responsible for processing audio messages and documents
@@ -10,21 +12,30 @@ export class AudioProcessorService {
   private readonly whisperService: WhisperService;
   private readonly gptService: GPTService;
 
-  constructor() {
+  constructor(usageTrackingService?: UsageTrackingService) {
     // Initialize WhisperService with English-only enforcement
     this.whisperService = new WhisperService({
       enforceEnglishOnly: true,
       language: 'en',
-    });
+    }, usageTrackingService);
 
     // Initialize GPTService for text processing
-    this.gptService = new GPTService();
+    this.gptService = new GPTService(undefined, undefined, usageTrackingService);
   }
 
   /**
    * Processes audio messages (voice notes, audio files)
    */
-  async processAudioMessage(fileUrl: string, userId?: number): Promise<string> {
+  async processAudioMessage(fileUrl: string, userId?: number, context?: ProcessingContext): Promise<string> {
+    const result = await this.processAudioMessageDetailed(fileUrl, userId, context);
+    return result.responseText;
+  }
+
+  async processAudioMessageDetailed(
+    fileUrl: string,
+    userId?: number,
+    context?: ProcessingContext,
+  ): Promise<ProcessorResponse> {
     logger.info('Processing audio message', {
       userId,
       fileUrl: fileUrl.substring(0, 50) + '...', // Log partial URL for privacy
@@ -32,28 +43,34 @@ export class AudioProcessorService {
 
     try {
       // Transcribe the audio using Whisper service
-      const transcriptionResult = await this.whisperService.transcribeAudio(fileUrl, userId);
+      const transcriptionResult = await this.whisperService.transcribeAudio(fileUrl, userId, context);
 
       const { text, processingTimeMs } = transcriptionResult;
 
       // If transcription is empty or too short, provide helpful feedback
       if (!text || text.trim().length < 2) {
-        return (
-          `🎵 Audio received and processed, but no speech was detected.\n` +
-          `⏱️ Processing time: ${Math.round(processingTimeMs / 1000)}s\n`
-        );
+        return {
+          responseText:
+            `🎵 Audio received and processed, but no speech was detected.\n` +
+            `⏱️ Processing time: ${Math.round(processingTimeMs / 1000)}s\n`,
+          processingTimeMs,
+        };
       }
 
       // Process the transcribed text with GPT
       try {
-        const response = await this.gptService.processMessage(text, userId?.toString());
+        const response = await this.gptService.processMessageDetailed(text, userId?.toString(), context);
 
         const finalResponse =
           `📝 What you said: ${text}\n\n` +
-          `🤖 Response: ${response}\n\n` +
+          `🤖 Response: ${response.response}\n\n` +
           `⏱️ Transcription: ${Math.round(processingTimeMs / 1000)}s`;
 
-        return finalResponse;
+        return {
+          responseText: finalResponse,
+          processingTimeMs,
+          transcriptionText: text,
+        };
       } catch (gptError) {
         logger.warn('Failed to process transcribed audio with GPT', {
           userId,
@@ -62,12 +79,15 @@ export class AudioProcessorService {
         });
 
         // Fallback to just showing transcription if GPT processing fails
-        return (
-          `🎵 Audio transcribed successfully!\n\n` +
-          `📝 What you said: ${text}\n\n` +
-          `⏱️ ${Math.round(processingTimeMs / 1000)}s\n` +
-          `🤖 (Response generation temporarily unavailable)`
-        );
+        return {
+          responseText:
+            `🎵 Audio transcribed successfully!\n\n` +
+            `📝 What you said: ${text}\n\n` +
+            `⏱️ ${Math.round(processingTimeMs / 1000)}s\n` +
+            `🤖 (Response generation temporarily unavailable)`,
+          processingTimeMs,
+          transcriptionText: text,
+        };
       }
     } catch (error) {
       logger.error('Failed to process audio message', {
@@ -75,7 +95,9 @@ export class AudioProcessorService {
         error: (error as Error).message,
       });
 
-      return this.handleAudioProcessingError(error as Error);
+      return {
+        responseText: this.handleAudioProcessingError(error as Error),
+      };
     }
   }
 
@@ -87,7 +109,19 @@ export class AudioProcessorService {
     fileName: string,
     mimeType: string,
     userId?: number,
+    context?: ProcessingContext,
   ): Promise<string> {
+    const result = await this.processAudioDocumentDetailed(fileUrl, fileName, mimeType, userId, context);
+    return result.responseText;
+  }
+
+  async processAudioDocumentDetailed(
+    fileUrl: string,
+    fileName: string,
+    mimeType: string,
+    userId?: number,
+    context?: ProcessingContext,
+  ): Promise<ProcessorResponse> {
     logger.info('Processing audio document', {
       userId,
       fileName,
@@ -96,31 +130,37 @@ export class AudioProcessorService {
 
     try {
       // Use the same transcription logic as audio messages
-      const transcriptionResult = await this.whisperService.transcribeAudio(fileUrl, userId);
+      const transcriptionResult = await this.whisperService.transcribeAudio(fileUrl, userId, context);
 
       const { text, processingTimeMs, fileSizeBytes } = transcriptionResult;
 
       // If transcription is empty or too short, provide helpful feedback
       if (!text || text.trim().length < 2) {
-        return (
-          `📁 Audio document "${fileName}" processed, but no speech was detected.\n` +
-          `🎼 Type: ${mimeType}\n` +
-          `⏱️ Processing time: ${Math.round(processingTimeMs / 1000)}s\n`
-        );
+        return {
+          responseText:
+            `📁 Audio document "${fileName}" processed, but no speech was detected.\n` +
+            `🎼 Type: ${mimeType}\n` +
+            `⏱️ Processing time: ${Math.round(processingTimeMs / 1000)}s\n`,
+          processingTimeMs,
+        };
       }
 
       // Process the transcribed text with GPT
       try {
-        const response = await this.gptService.processMessage(text, userId?.toString());
+        const response = await this.gptService.processMessageDetailed(text, userId?.toString(), context);
 
         const finalResponse =
           `📁 Audio document "${fileName}" processed successfully!\n` +
           `🎼 Type: ${mimeType}\n\n` +
           `📝 What was said: ${text}\n\n` +
-          `🤖 Response: ${response}\n\n` +
+          `🤖 Response: ${response.response}\n\n` +
           `⏱️ Transcription: ${Math.round(processingTimeMs / 1000)}s`;
 
-        return finalResponse;
+        return {
+          responseText: finalResponse,
+          processingTimeMs,
+          transcriptionText: text,
+        };
       } catch (gptError) {
         logger.warn('Failed to process transcribed audio document with GPT', {
           userId,
@@ -130,13 +170,16 @@ export class AudioProcessorService {
         });
 
         // Fallback to just showing transcription if GPT processing fails
-        return (
-          `📁 Audio document "${fileName}" transcribed successfully!\n` +
-          `🎼 Type: ${mimeType}\n\n` +
-          `📝 What was said: ${text}\n\n` +
-          `⏱️ ${Math.round(processingTimeMs / 1000)}s\n` +
-          `🤖 (Response generation temporarily unavailable)`
-        );
+        return {
+          responseText:
+            `📁 Audio document "${fileName}" transcribed successfully!\n` +
+            `🎼 Type: ${mimeType}\n\n` +
+            `📝 What was said: ${text}\n\n` +
+            `⏱️ ${Math.round(processingTimeMs / 1000)}s\n` +
+            `🤖 (Response generation temporarily unavailable)`,
+          processingTimeMs,
+          transcriptionText: text,
+        };
       }
     } catch (error) {
       logger.error('Failed to process audio document', {
@@ -146,7 +189,9 @@ export class AudioProcessorService {
         error: (error as Error).message,
       });
 
-      return this.handleAudioDocumentError(error as Error, fileName, mimeType);
+      return {
+        responseText: this.handleAudioDocumentError(error as Error, fileName, mimeType),
+      };
     }
   }
 

--- a/src/services/telegram/processors/text-processor.service.ts
+++ b/src/services/telegram/processors/text-processor.service.ts
@@ -2,6 +2,8 @@
 import { logger } from '../../../utils/logger';
 import { GPTService } from '../../ai';
 import { ToolDispatcher } from '../../../types/tool.types';
+import { ProcessorResponse, ProcessingContext } from '../../../types/processing.types';
+import { UsageTrackingService } from '../../persistence';
 
 /**
  * Service responsible for processing text messages
@@ -9,15 +11,24 @@ import { ToolDispatcher } from '../../../types/tool.types';
 export class TextProcessorService {
   private readonly gptService: GPTService;
 
-  constructor(toolDispatcher?: ToolDispatcher) {
+  constructor(toolDispatcher?: ToolDispatcher, usageTrackingService?: UsageTrackingService) {
     // Initialize GPTService with tool dispatcher for function calling
-    this.gptService = new GPTService(toolDispatcher);
+    this.gptService = new GPTService(toolDispatcher, undefined, usageTrackingService);
   }
 
   /**
    * Processes text messages from users
    */
-  async processTextMessage(text: string, userId?: number): Promise<string> {
+  async processTextMessage(text: string, userId?: number, context?: ProcessingContext): Promise<string> {
+    const result = await this.processTextMessageDetailed(text, userId, context);
+    return result.responseText;
+  }
+
+  async processTextMessageDetailed(
+    text: string,
+    userId?: number,
+    context?: ProcessingContext,
+  ): Promise<ProcessorResponse> {
     logger.info('Processing text message', {
       userId,
       messageLength: text.length,
@@ -25,15 +36,18 @@ export class TextProcessorService {
 
     try {
       // Process the message using GPT
-      const response = await this.gptService.processMessage(text, userId?.toString());
+      const response = await this.gptService.processMessageDetailed(text, userId?.toString(), context);
 
       logger.info('Text message processed successfully', {
         userId,
         messageLength: text.length,
-        responseLength: response.length,
+        responseLength: response.response.length,
       });
 
-      return response;
+      return {
+        responseText: response.response,
+        processingTimeMs: response.processingTimeMs,
+      };
     } catch (error) {
       logger.error('Failed to process text message', {
         userId,
@@ -41,7 +55,9 @@ export class TextProcessorService {
         error: (error as Error).message,
       });
 
-      return this.handleTextProcessingError(error as Error, text);
+      return {
+        responseText: this.handleTextProcessingError(error as Error, text),
+      };
     }
   }
 

--- a/src/services/telegram/telegram-bot.service.ts
+++ b/src/services/telegram/telegram-bot.service.ts
@@ -10,6 +10,7 @@ import { BotActivityService } from './bot-activity.service';
 import { BotStatusService } from './bot-status.service';
 import { TodoistAPIService } from '../external/todoist-api.service';
 import { GPT_CONSTANTS } from '../ai/constants/gpt.constants';
+import { ConversationStoreService, JobStateService, UsageTrackingService } from '../persistence';
 
 /**
  * Service class responsible for managing Telegram bot operations
@@ -25,7 +26,12 @@ export class TelegramBotService {
 
   constructor(
     config: TelegramConfig,
-    messageProcessor: MessageProcessorService
+    messageProcessor: MessageProcessorService,
+    persistence?: {
+      conversationStore?: ConversationStoreService;
+      jobStateService?: JobStateService;
+      usageTrackingService?: UsageTrackingService;
+    },
   ) {
     this.botToken = config.token;
     this.bot = new Telegraf(config.token);
@@ -43,6 +49,9 @@ export class TelegramBotService {
       this.messageProcessor,
       this.activityService,
       this.statusService,
+      persistence?.conversationStore,
+      persistence?.jobStateService,
+      persistence?.usageTrackingService,
     );
 
     this.setupBotHandlers();

--- a/src/types/gpt.types.ts
+++ b/src/types/gpt.types.ts
@@ -34,6 +34,10 @@ export interface MessageProcessingResult {
   functionCallsCount: number;
   /** Model used for generation */
   model: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  estimatedCostUsd?: number;
 }
 
 /**

--- a/src/types/processing.types.ts
+++ b/src/types/processing.types.ts
@@ -1,0 +1,11 @@
+export interface ProcessingContext {
+  jobId?: string;
+  sourceMessageId?: string;
+  chatId?: string;
+}
+
+export interface ProcessorResponse {
+  responseText: string;
+  processingTimeMs?: number;
+  transcriptionText?: string;
+}

--- a/tests/unit/services/persistence/persistence.test.ts
+++ b/tests/unit/services/persistence/persistence.test.ts
@@ -1,0 +1,222 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  ConversationStoreService,
+  DatabaseService,
+  JobRepository,
+  JobStateService,
+  MessageRepository,
+  MigrationRunner,
+  PendingClarificationRepository,
+  UsageEventRepository,
+  UsageTrackingService,
+  UserPreferencesRepository,
+} from '../../../../src/services/persistence';
+import { MessageHandlers } from '../../../../src/services/telegram/handlers/message-handlers';
+
+describe('Persistence layer', () => {
+  async function createPersistence() {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jarvis-db-'));
+    const databasePath = path.join(tempDir, 'jarvis.db');
+    const database = new DatabaseService({
+      path: databasePath,
+      verboseLogging: false,
+    });
+
+    await database.init();
+    const migrationRunner = new MigrationRunner(database);
+    await migrationRunner.runMigrations();
+
+    const messageRepository = new MessageRepository(database);
+    const jobRepository = new JobRepository(database);
+    const clarificationRepository = new PendingClarificationRepository(database);
+    const preferencesRepository = new UserPreferencesRepository(database);
+    const usageRepository = new UsageEventRepository(database);
+
+    return {
+      tempDir,
+      database,
+      migrationRunner,
+      messageRepository,
+      jobRepository,
+      clarificationRepository,
+      preferencesRepository,
+      usageRepository,
+      conversationStore: new ConversationStoreService(messageRepository),
+      jobStateService: new JobStateService(jobRepository),
+      usageTrackingService: new UsageTrackingService(usageRepository),
+    };
+  }
+
+  afterEach(async () => {
+    // cleanup handled per-test to preserve explicit close ordering
+  });
+
+  it('applies migrations idempotently', async () => {
+    const persistence = await createPersistence();
+
+    await persistence.migrationRunner.runMigrations();
+
+    const migrationRows = await persistence.database.all<{ version: number }>(
+      'SELECT version FROM schema_migrations ORDER BY version ASC',
+    );
+    const tables = await persistence.database.all<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('messages', 'jobs', 'pending_clarifications', 'user_preferences', 'usage_events')",
+    );
+
+    expect(migrationRows).toEqual([{ version: 1 }]);
+    expect(tables.map((table) => table.name).sort()).toEqual([
+      'jobs',
+      'messages',
+      'pending_clarifications',
+      'usage_events',
+      'user_preferences',
+    ]);
+
+    await persistence.database.close();
+    fs.rmSync(persistence.tempDir, { recursive: true, force: true });
+  });
+
+  it('supports preference upserts, clarification state, and usage summaries', async () => {
+    const persistence = await createPersistence();
+
+    const firstPreference = await persistence.preferencesRepository.setPreference('123', 'tone', {
+      value: 'concise',
+    });
+    const secondPreference = await persistence.preferencesRepository.setPreference('123', 'tone', {
+      value: 'detailed',
+    });
+    const clarification = await persistence.clarificationRepository.createPendingClarification({
+      userId: '123',
+      chatId: '456',
+      questionText: 'Delete the task?',
+      proposedAction: { action: 'delete_task' },
+    });
+    await persistence.clarificationRepository.resolveClarification(clarification.id, 'answered');
+    await persistence.usageRepository.recordEvent({
+      userId: '123',
+      chatId: '456',
+      eventType: 'gpt_response',
+      inputTokens: 10,
+      outputTokens: 5,
+      estimatedCostUsd: 0.01,
+    });
+    await persistence.usageRepository.recordEvent({
+      userId: '123',
+      chatId: '456',
+      eventType: 'tool_completed',
+      inputTokens: 2,
+      outputTokens: 1,
+      estimatedCostUsd: 0.005,
+    });
+
+    const storedPreference = await persistence.preferencesRepository.getPreference('123', 'tone');
+    const activeClarification = await persistence.clarificationRepository.findActiveByUser('123');
+    const usageSummary = await persistence.usageRepository.summarizeUsageForUser(
+      '123',
+      '1970-01-01T00:00:00.000Z',
+    );
+
+    expect(firstPreference.preferenceValue).toEqual({ value: 'concise' });
+    expect(secondPreference.preferenceValue).toEqual({ value: 'detailed' });
+    expect(storedPreference?.preferenceValue).toEqual({ value: 'detailed' });
+    expect(activeClarification).toBeNull();
+    expect(usageSummary).toEqual({
+      eventCount: 2,
+      totalInputTokens: 12,
+      totalOutputTokens: 6,
+      totalEstimatedCostUsd: 0.015,
+    });
+
+    await persistence.database.close();
+    fs.rmSync(persistence.tempDir, { recursive: true, force: true });
+  });
+
+  it('persists inbound messages, completed jobs, and outbound replies for text handling', async () => {
+    const persistence = await createPersistence();
+    const handlers = new MessageHandlers(
+      {} as any,
+      {
+        processTextMessageDetailed: jest.fn().mockResolvedValue({
+          responseText: 'stored response',
+          processingTimeMs: 1200,
+        }),
+      } as any,
+      { recordActivity: jest.fn() } as any,
+      persistence.conversationStore,
+      persistence.jobStateService,
+      persistence.usageTrackingService,
+    );
+
+    await handlers.handleText({
+      from: { id: 123, username: 'tester' },
+      chat: { id: 456 },
+      update: { update_id: 789 },
+      message: { message_id: 321, text: 'hello persistence' },
+      reply: jest.fn().mockResolvedValue({ message_id: 654 }),
+    } as any);
+
+    const messages = await persistence.messageRepository.listRecentMessagesByUser('123', 10);
+    const jobs = await persistence.jobRepository.listActiveJobsByUser('123');
+    const completedJob = await persistence.database.get<{ status: string; result_json: string }>(
+      'SELECT status, result_json FROM jobs LIMIT 1',
+    );
+    const usageEvents = await persistence.usageRepository.listEventsForUser('123', 10);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0].direction).toBe('outgoing');
+    expect(messages[1].direction).toBe('incoming');
+    expect(messages[1].status).toBe('processed');
+    expect(jobs).toEqual([]);
+    expect(completedJob?.status).toBe('completed');
+    expect(completedJob?.result_json).toContain('stored response');
+    expect(usageEvents.some((event) => event.eventType === 'message_processed')).toBe(true);
+
+    await persistence.database.close();
+    fs.rmSync(persistence.tempDir, { recursive: true, force: true });
+  });
+
+  it('marks message and job as failed when text processing throws', async () => {
+    const persistence = await createPersistence();
+    const handlers = new MessageHandlers(
+      {} as any,
+      {
+        processTextMessageDetailed: jest.fn().mockRejectedValue(new Error('processor blew up')),
+      } as any,
+      { recordActivity: jest.fn() } as any,
+      persistence.conversationStore,
+      persistence.jobStateService,
+      persistence.usageTrackingService,
+    );
+
+    await handlers.handleText({
+      from: { id: 123, username: 'tester' },
+      chat: { id: 456 },
+      update: { update_id: 790 },
+      message: { message_id: 322, text: 'this will fail' },
+      reply: jest.fn().mockResolvedValue({ message_id: 655 }),
+    } as any);
+
+    const failedMessage = await persistence.database.get<{ status: string; error_message: string | null }>(
+      "SELECT status, error_message FROM messages WHERE direction = 'incoming' LIMIT 1",
+    );
+    const failedJob = await persistence.database.get<{ status: string; error_message: string | null }>(
+      'SELECT status, error_message FROM jobs LIMIT 1',
+    );
+    const usageEvents = await persistence.usageRepository.listEventsForUser('123', 10);
+
+    expect(failedMessage).toEqual({
+      status: 'failed',
+      error_message: 'processor blew up',
+    });
+    expect(failedJob).toEqual({
+      status: 'failed',
+      error_message: 'processor blew up',
+    });
+    expect(usageEvents.some((event) => event.eventType === 'error')).toBe(true);
+
+    await persistence.database.close();
+    fs.rmSync(persistence.tempDir, { recursive: true, force: true });
+  });
+});

--- a/tests/unit/services/telegram/handlers/message-handlers.test.ts
+++ b/tests/unit/services/telegram/handlers/message-handlers.test.ts
@@ -4,6 +4,8 @@ describe('MessageHandlers', () => {
   function createContext(message: Record<string, unknown>) {
     return {
       from: { id: 123, username: 'tester' },
+      chat: { id: 456 },
+      update: { update_id: 789 },
       message,
       reply: jest.fn().mockResolvedValue(undefined),
     } as any;
@@ -16,6 +18,9 @@ describe('MessageHandlers', () => {
     } as any;
     const messageProcessor = {
       processAudioDocument: jest.fn().mockResolvedValue('processed document'),
+      processAudioDocumentDetailed: jest.fn().mockResolvedValue({
+        responseText: 'processed document',
+      }),
       processAudioMessage: jest.fn(),
     } as any;
     const activityService = {
@@ -35,11 +40,14 @@ describe('MessageHandlers', () => {
 
     expect(fileService.isAudioFile).toHaveBeenCalledWith('audio/mpeg');
     expect(fileService.getFileUrl).toHaveBeenCalledWith('file-1');
-    expect(messageProcessor.processAudioDocument).toHaveBeenCalledWith(
+    expect(messageProcessor.processAudioDocumentDetailed).toHaveBeenCalledWith(
       'https://example.com/file.mp3',
       'meeting.mp3',
       'audio/mpeg',
       123,
+      expect.objectContaining({
+        chatId: '456',
+      }),
     );
     expect(messageProcessor.processAudioMessage).not.toHaveBeenCalled();
     expect(activityService.recordActivity).toHaveBeenCalledWith('message_document');
@@ -53,6 +61,7 @@ describe('MessageHandlers', () => {
     } as any;
     const messageProcessor = {
       processAudioDocument: jest.fn(),
+      processAudioDocumentDetailed: jest.fn(),
     } as any;
     const activityService = {
       recordActivity: jest.fn(),
@@ -83,6 +92,7 @@ describe('MessageHandlers', () => {
     } as any;
     const messageProcessor = {
       processAudioDocument: jest.fn(),
+      processAudioDocumentDetailed: jest.fn(),
     } as any;
     const activityService = {
       recordActivity: jest.fn(),


### PR DESCRIPTION
## Summary
Add a SQLite-backed persistence layer and wire it through the Telegram processing flow.

## Why
The bot was mostly stateless, which blocked durable message history, job tracking, clarification state, and usage analytics. This change establishes the persistence foundation needed for later async execution and memory features.

## Changes made
- add a persistence module with database bootstrap, migrations, repositories, and focused storage services
- persist inbound and outbound Telegram messages plus synchronous job lifecycle state
- instrument GPT, Whisper, webhook, and handler flows with usage events and duplicate update detection
- add DB-backed unit coverage for migrations, repository behavior, and persisted handler flows

## Testing
- npm run build
- npm test -- --runInBand
- npm run lint

## Notes
This keeps execution synchronous for now and introduces async-ready job records without adding a queue or worker system yet.