### PR TITLE
[Feature] add structured observability foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Telegram → Webhook → ngrok → Your Server → Bot Service → Response → 
 # Check if your server is accessible
 curl http://localhost:3000/ping
 
+# Check Prometheus-style metrics
+curl http://localhost:3000/metrics
+
 # Check ngrok status
 curl https://your-ngrok-url.ngrok-free.app/ping
 
@@ -179,5 +182,9 @@ tail -f logs/app.log  # if you add file logging
 | `TEST_CHAT_ID` | Your Telegram user ID for testing | `987654321` |
 | `PORT` | Local server port | `3000` |
 | `NODE_ENV` | Environment mode | `development` |
+
+## Observability
+
+The app now emits structured JSON logs and exposes `/metrics` for local monitoring. See [docs/observability.md](/Users/Spare/Desktop/jarvis-mcp/docs/observability.md) for the full metric list, redaction rules, and suggested dashboard panels.
 
 Your bot is well-structured and ready to go! Just fix the environment variables and you should be able to start testing.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,78 @@
+# Observability
+
+Jarvis now exposes a local-first observability surface:
+
+- Structured JSON logs with request-scoped correlation fields
+- `/metrics` in Prometheus text format
+- Token and latency metrics for OpenAI requests
+- Whisper and tool execution timing/failure metrics
+
+## Correlation fields
+
+Every inbound webhook request creates a `requestId`. That context is threaded through the Telegram update pipeline and can include:
+
+- `requestId`
+- `updateId`
+- `chatId`
+- `userId`
+- `messageType`
+- `jobId` for future async work
+- `component`
+- `stage`
+
+## Log behavior
+
+Logs are JSON by default and redact:
+
+- `BOT_TOKEN`
+- `TELEGRAM_SECRET_TOKEN`
+- `OPENAI_API_KEY`
+- `TODOIST_API_KEY`
+- Telegram file download URLs
+
+User message bodies are not logged directly. The system records lengths, counts, IDs, and hashes instead.
+
+## Metrics
+
+Use the metrics endpoint locally:
+
+```bash
+curl http://localhost:3000/metrics
+```
+
+Primary metrics exposed:
+
+- `jarvis_webhook_requests_total`
+- `jarvis_webhook_duration_ms`
+- `jarvis_telegram_updates_total`
+- `jarvis_message_processing_duration_ms`
+- `jarvis_message_processing_failures_total`
+- `jarvis_openai_requests_total`
+- `jarvis_openai_request_duration_ms`
+- `jarvis_openai_tokens_total`
+- `jarvis_whisper_requests_total`
+- `jarvis_whisper_duration_ms`
+- `jarvis_tool_calls_total`
+- `jarvis_tool_call_duration_ms`
+- `jarvis_process_uptime_seconds`
+- `jarvis_uncaught_errors_total`
+
+## Suggested local dashboard panels
+
+- Webhook request rate and error rate
+- Webhook p50/p95 latency
+- OpenAI request latency by operation
+- OpenAI token volume over time
+- Whisper success/error count and latency
+- Tool call success/error count by tool
+- Fatal runtime error count
+
+## Useful env vars
+
+```env
+LOG_LEVEL=debug
+LOG_PRETTY=false
+METRICS_ENABLED=true
+SERVICE_NAME=jarvis-mcp
+SERVICE_VERSION=1.0.0
+```

--- a/reports/FUTURE_ENHANCEMENTS.md
+++ b/reports/FUTURE_ENHANCEMENTS.md
@@ -431,6 +431,63 @@ Read, search, send, and manage Gmail through Jarvis voice or text commands.
 
 ---
 
+### Email-Triggered Telegram Prompts and Approval Flows
+Jarvis should not only wait for user-initiated commands. It should also be able to watch incoming email events, run a pipeline automatically, and proactively ask the user what to do next inside Telegram.
+
+**What it enables:**
+- Trigger rules based on sender, labels, thread type, or lightweight classification
+- Telegram prompts with inline buttons such as `Yes` / `No`, `Accept draft`, or `Reject`
+- Approval workflows before taking a mutating action
+- Turning passive inbox activity into actionable decisions without opening Gmail
+
+**Example flows:**
+- Email from DBS arrives → run a spending-classification pipeline → Jarvis asks: "Add this to your spending?" with Telegram buttons
+- A person emails you directly → run a reply-drafting pipeline → Jarvis asks whether to accept the draft, reject it, or rewrite in your own style
+- A transactional email arrives → extract structured data first, then ask whether to log it somewhere
+
+**Implementation path:**
+- Add Gmail watch or polling support for new-message events
+- Define trigger rules such as `{ sender, label, classifier, pipelineId }`
+- Add a pipeline stage that can emit a user prompt instead of a final action
+- Support Telegram inline keyboards and callback handling for button-based approvals
+- Persist pending approval state so button presses can resume the correct workflow
+
+**Design considerations:**
+- Avoid spamming Telegram for low-value email
+- Group or debounce related prompts where possible
+- Require explicit approval before send, reply, or write actions
+- Keep the prompt short and show only the context needed to decide
+
+---
+
+### Proactive Incoming Email Summaries
+Jarvis should be able to summarize new emails automatically and deliver the important context in Telegram so the user does not need to open Gmail just to know what came in.
+
+**What it enables:**
+- Short summaries for new inbound mail
+- Sender-aware prioritization so only important email becomes a notification
+- Thread-level context such as "new reply in an ongoing conversation"
+- Triage actions directly from Telegram, such as archive, draft reply, or create a task
+
+**Example outputs:**
+- "DBS emailed you a new card statement. Total due: X. Payment date: Y."
+- "Alice replied about Friday's meeting. She confirmed 3 PM and asked for the latest deck."
+- "Shopee sent a shipment update. Package is out for delivery today."
+
+**Implementation path:**
+- Reuse the Gmail ingestion path for new-message detection
+- Add an email summarization stage that extracts sender, intent, urgency, and requested action
+- Route summaries to Telegram with configurable notification rules
+- Let summary messages offer follow-up actions such as `Draft reply`, `Add task`, or `Ignore`
+
+**Design considerations:**
+- Tune notification thresholds so summaries stay useful instead of noisy
+- Collapse bulk mail and low-signal marketing messages by default
+- Redact or truncate sensitive content unless the user explicitly asks for the full body
+- Prefer concise structured summaries over long paraphrases
+
+---
+
 ### Reminders / Scheduled Messages
 Using a cron-like system, Jarvis could:
 
@@ -508,7 +565,9 @@ If building this incrementally, the most practical order is:
 10. Notion integration
 11. Google Calendar integration
 12. Gmail integration
-13. Reminders / scheduled messages
-14. Image understanding
-15. Docker / deployment hardening
-16. Developer experience improvements
+13. Email-triggered Telegram prompts and approval flows
+14. Proactive incoming email summaries
+15. Reminders / scheduled messages
+16. Image understanding
+17. Docker / deployment hardening
+18. Developer experience improvements

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,4 +38,6 @@ const telegramConfig: TelegramConfig = {
 
 export const botService = new TelegramBotService(telegramConfig, messageProcessor);
 
-logger.info('Services initialised');
+logger.info('app.services_initialized', {
+  hasToolDispatcher: true,
+});

--- a/src/controllers/webhook.controller.ts
+++ b/src/controllers/webhook.controller.ts
@@ -1,27 +1,50 @@
 // services/webhook.controller.ts
 import express from 'express';
 import type { TelegramBotService } from '../services/telegram/telegram-bot.service';
-import { logger } from '../utils/logger';
+import { createTelemetryContext, recordWebhook } from '../observability';
+import { getLogger, serializeError } from '../utils/logger';
 
 export function createWebhookRouter(botService: TelegramBotService) {
   const router = express.Router();
 
   router.post('/webhook/:secret', express.json(), async (req, res): Promise<void> => {
+    const updateId = typeof req.body?.update_id === 'number' ? req.body.update_id : undefined;
+    const context = createTelemetryContext({
+      updateId,
+      component: 'webhook',
+      stage: 'ingress',
+    });
+    const requestLogger = getLogger(context);
+    const startTime = Date.now();
+
+    requestLogger.info('webhook.received', {
+      ip: req.ip,
+      hasUpdateBody: !!req.body,
+    });
+
     const secret = req.params.secret;
     if (!secret || secret !== process.env.TELEGRAM_SECRET_TOKEN) {
-      logger.warn('Unauthorized webhook attempt', { ip: req.ip, secret });
+      requestLogger.warn('webhook.rejected', { ip: req.ip });
+      recordWebhook('rejected', Date.now() - startTime);
       res.sendStatus(401);
       return;
     }
+
     try {
-      await botService.handleUpdate(req.body);
+      await botService.handleUpdate(req.body, context);
+      requestLogger.info('webhook.completed', {
+        durationMs: Date.now() - startTime,
+        statusCode: 200,
+      });
+      recordWebhook('success', Date.now() - startTime);
       res.sendStatus(200);
       return;
     } catch (err) {
-      logger.error('Webhook handler failed', {
-        error: (err as Error).message,
-        stack: (err as Error).stack,
+      requestLogger.error('webhook.failed', {
+        ...serializeError(err),
+        durationMs: Date.now() - startTime,
       });
+      recordWebhook('error', Date.now() - startTime);
       res.status(500).json({ error: 'Internal Server Error' });
       return;
     }

--- a/src/observability/context.ts
+++ b/src/observability/context.ts
@@ -1,0 +1,49 @@
+import { AsyncLocalStorage } from 'async_hooks';
+import { randomUUID, createHash } from 'crypto';
+import { TelemetryContext } from './types';
+
+const telemetryStorage = new AsyncLocalStorage<TelemetryContext>();
+
+function stripUndefined<T extends object>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, fieldValue]) => fieldValue !== undefined),
+  ) as T;
+}
+
+export function createTelemetryContext(context: Partial<TelemetryContext> = {}): TelemetryContext {
+  return stripUndefined({
+    requestId: context.requestId || randomUUID(),
+    updateId: context.updateId,
+    chatId: context.chatId,
+    userId: context.userId,
+    messageType: context.messageType,
+    jobId: context.jobId,
+    component: context.component,
+    stage: context.stage,
+  });
+}
+
+export function extendTelemetryContext(
+  context: TelemetryContext | undefined,
+  patch: Partial<TelemetryContext>,
+): TelemetryContext {
+  return createTelemetryContext({
+    ...(context || {}),
+    ...patch,
+  });
+}
+
+export function runWithTelemetryContext<T>(
+  context: TelemetryContext,
+  callback: () => T | Promise<T>,
+): T | Promise<T> {
+  return telemetryStorage.run(context, callback);
+}
+
+export function getTelemetryContext(): TelemetryContext | undefined {
+  return telemetryStorage.getStore();
+}
+
+export function hashContent(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+}

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './context';
+export * from './metrics';
+export * from './pricing';

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -1,0 +1,311 @@
+const METRICS_ENABLED = process.env.METRICS_ENABLED !== 'false';
+
+type Labels = Record<string, string>;
+
+interface MetricRecord {
+  value: number;
+  labels: Labels;
+}
+
+interface HistogramRecord {
+  sum: number;
+  count: number;
+  buckets: Map<number, number>;
+  labels: Labels;
+}
+
+const metricHelp = new Map<string, string>();
+const counters = new Map<string, Map<string, MetricRecord>>();
+const gauges = new Map<string, Map<string, MetricRecord>>();
+const histograms = new Map<string, Map<string, HistogramRecord>>();
+
+const webhookBuckets = [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
+const messageBuckets = [25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000];
+const openAIBuckets = [50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000];
+const toolBuckets = [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
+
+function isEnabled(): boolean {
+  return METRICS_ENABLED;
+}
+
+function ensureHelp(name: string, help: string): void {
+  if (!metricHelp.has(name)) {
+    metricHelp.set(name, help);
+  }
+}
+
+function serializeLabels(labels: Labels): string {
+  return Object.entries(labels)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('|');
+}
+
+function formatLabels(labels: Labels): string {
+  const entries = Object.entries(labels).sort(([left], [right]) => left.localeCompare(right));
+  if (entries.length === 0) {
+    return '';
+  }
+
+  return `{${entries
+    .map(([key, value]) => `${key}="${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`)
+    .join(',')}}`;
+}
+
+function incrementCounter(name: string, help: string, labels: Labels, value = 1): void {
+  ensureHelp(name, help);
+  const bucket = counters.get(name) || new Map<string, MetricRecord>();
+  const key = serializeLabels(labels);
+  const current = bucket.get(key) || { value: 0, labels };
+  current.value += value;
+  bucket.set(key, current);
+  counters.set(name, bucket);
+}
+
+function setGauge(name: string, help: string, labels: Labels, value: number): void {
+  ensureHelp(name, help);
+  const bucket = gauges.get(name) || new Map<string, MetricRecord>();
+  bucket.set(serializeLabels(labels), { value, labels });
+  gauges.set(name, bucket);
+}
+
+function observeHistogram(
+  name: string,
+  help: string,
+  labels: Labels,
+  value: number,
+  buckets: number[],
+): void {
+  ensureHelp(name, help);
+  const histogram = histograms.get(name) || new Map<string, HistogramRecord>();
+  const key = serializeLabels(labels);
+  const current =
+    histogram.get(key) ||
+    ({
+      sum: 0,
+      count: 0,
+      buckets: new Map<number, number>(buckets.map((bucket) => [bucket, 0])),
+      labels,
+    } satisfies HistogramRecord);
+
+  current.sum += value;
+  current.count += 1;
+  for (const bucket of buckets) {
+    if (value <= bucket) {
+      current.buckets.set(bucket, (current.buckets.get(bucket) || 0) + 1);
+    }
+  }
+
+  histogram.set(key, current);
+  histograms.set(name, histogram);
+}
+
+type OpenAIUsage = {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+};
+
+export function recordWebhook(status: 'success' | 'rejected' | 'error', durationMs: number): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_webhook_requests_total',
+    'Total webhook requests by status',
+    { status },
+  );
+  observeHistogram(
+    'jarvis_webhook_duration_ms',
+    'Webhook request duration in milliseconds',
+    {},
+    durationMs,
+    webhookBuckets,
+  );
+}
+
+export function recordTelegramUpdate(type: string): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_telegram_updates_total',
+    'Telegram updates processed by type',
+    { type: type || 'unknown' },
+  );
+}
+
+export function recordMessageProcessingDuration(messageType: string, durationMs: number): void {
+  if (!isEnabled()) return;
+  observeHistogram(
+    'jarvis_message_processing_duration_ms',
+    'Message processing duration by message type',
+    { message_type: messageType || 'unknown' },
+    durationMs,
+    messageBuckets,
+  );
+}
+
+export function recordMessageProcessingFailure(messageType: string, stage: string): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_message_processing_failures_total',
+    'Message processing failures by message type and stage',
+    { message_type: messageType || 'unknown', stage: stage || 'unknown' },
+  );
+}
+
+export function recordOpenAIRequest(
+  labels: { model: string; operation: string; status: string },
+  durationMs: number,
+  usage?: OpenAIUsage,
+): void {
+  if (!isEnabled()) return;
+
+  const safeLabels = {
+    model: labels.model || 'unknown',
+    operation: labels.operation || 'unknown',
+    status: labels.status || 'unknown',
+  };
+
+  incrementCounter(
+    'jarvis_openai_requests_total',
+    'OpenAI requests by model, operation, and status',
+    safeLabels,
+  );
+  observeHistogram(
+    'jarvis_openai_request_duration_ms',
+    'OpenAI request duration by model and operation',
+    { model: safeLabels.model, operation: safeLabels.operation },
+    durationMs,
+    openAIBuckets,
+  );
+
+  if (usage?.promptTokens !== undefined) {
+    incrementCounter(
+      'jarvis_openai_tokens_total',
+      'OpenAI token usage by model and direction',
+      { model: safeLabels.model, direction: 'prompt' },
+      usage.promptTokens,
+    );
+  }
+  if (usage?.completionTokens !== undefined) {
+    incrementCounter(
+      'jarvis_openai_tokens_total',
+      'OpenAI token usage by model and direction',
+      { model: safeLabels.model, direction: 'completion' },
+      usage.completionTokens,
+    );
+  }
+  if (usage?.totalTokens !== undefined) {
+    incrementCounter(
+      'jarvis_openai_tokens_total',
+      'OpenAI token usage by model and direction',
+      { model: safeLabels.model, direction: 'total' },
+      usage.totalTokens,
+    );
+  }
+}
+
+export function recordWhisperRequest(status: 'success' | 'error', durationMs: number): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_whisper_requests_total',
+    'Whisper requests by status',
+    { status },
+  );
+  observeHistogram(
+    'jarvis_whisper_duration_ms',
+    'Whisper processing duration in milliseconds',
+    {},
+    durationMs,
+    openAIBuckets,
+  );
+}
+
+export function recordToolCall(tool: string, status: 'success' | 'error', durationMs: number): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_tool_calls_total',
+    'Tool calls by tool name and status',
+    { tool: tool || 'unknown', status },
+  );
+  observeHistogram(
+    'jarvis_tool_call_duration_ms',
+    'Tool call duration by tool name',
+    { tool: tool || 'unknown' },
+    durationMs,
+    toolBuckets,
+  );
+}
+
+export function recordUncaughtError(kind: string): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_uncaught_errors_total',
+    'Uncaught process errors by kind',
+    { kind: kind || 'unknown' },
+  );
+}
+
+function renderCounter(name: string, values: Map<string, MetricRecord>): string[] {
+  return Array.from(values.values()).map(
+    (record) => `${name}${formatLabels(record.labels)} ${record.value}`,
+  );
+}
+
+function renderGauge(name: string, values: Map<string, MetricRecord>): string[] {
+  return Array.from(values.values()).map(
+    (record) => `${name}${formatLabels(record.labels)} ${record.value}`,
+  );
+}
+
+function renderHistogram(name: string, values: Map<string, HistogramRecord>): string[] {
+  const lines: string[] = [];
+
+  for (const value of values.values()) {
+    const sortedBuckets = Array.from(value.buckets.entries()).sort(([left], [right]) => left - right);
+    for (const [bucket, count] of sortedBuckets) {
+      lines.push(`${name}_bucket${formatLabels({ ...value.labels, le: String(bucket) })} ${count}`);
+    }
+    lines.push(`${name}_bucket${formatLabels({ ...value.labels, le: '+Inf' })} ${value.count}`);
+    lines.push(`${name}_sum${formatLabels(value.labels)} ${value.sum}`);
+    lines.push(`${name}_count${formatLabels(value.labels)} ${value.count}`);
+  }
+
+  return lines;
+}
+
+export async function getMetricsSnapshot(): Promise<string> {
+  if (!isEnabled()) {
+    return '';
+  }
+
+  setGauge('jarvis_process_uptime_seconds', 'Current process uptime in seconds', {}, process.uptime());
+
+  const lines: string[] = [];
+  for (const [name, help] of metricHelp.entries()) {
+    lines.push(`# HELP ${name} ${help}`);
+    const type = counters.has(name) ? 'counter' : gauges.has(name) ? 'gauge' : 'histogram';
+    lines.push(`# TYPE ${name} ${type}`);
+
+    if (counters.has(name)) {
+      lines.push(...renderCounter(name, counters.get(name)!));
+    } else if (gauges.has(name)) {
+      lines.push(...renderGauge(name, gauges.get(name)!));
+    } else if (histograms.has(name)) {
+      lines.push(...renderHistogram(name, histograms.get(name)!));
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function getMetricsContentType(): string {
+  return 'text/plain; version=0.0.4; charset=utf-8';
+}
+
+export function resetMetrics(): void {
+  counters.clear();
+  gauges.clear();
+  histograms.clear();
+  metricHelp.clear();
+}
+
+export { METRICS_ENABLED };

--- a/src/observability/pricing.ts
+++ b/src/observability/pricing.ts
@@ -1,0 +1,29 @@
+const OPENAI_PRICING_USD_PER_1K_TOKENS: Record<string, { input: number; output: number }> = {
+  'gpt-4o': { input: 0.005, output: 0.015 },
+  'gpt-4o-mini': { input: 0.00015, output: 0.0006 },
+  'gpt-4o-transcribe': { input: 0.006, output: 0 },
+};
+
+export interface CostEstimateInput {
+  model: string;
+  promptTokens?: number;
+  completionTokens?: number;
+}
+
+export function estimateOpenAICostUsd({
+  model,
+  promptTokens = 0,
+  completionTokens = 0,
+}: CostEstimateInput): number | undefined {
+  const pricing = OPENAI_PRICING_USD_PER_1K_TOKENS[model];
+  if (!pricing) {
+    return undefined;
+  }
+
+  return Number(
+    (
+      (promptTokens / 1000) * pricing.input +
+      (completionTokens / 1000) * pricing.output
+    ).toFixed(6),
+  );
+}

--- a/src/observability/types.ts
+++ b/src/observability/types.ts
@@ -1,0 +1,18 @@
+export type MessageType = 'text' | 'audio' | 'audio_document' | 'command' | 'unknown';
+
+export type PrimitiveLogValue = string | number | boolean | null | undefined;
+
+export type LogFields = Record<string, PrimitiveLogValue | PrimitiveLogValue[]>;
+
+export type MetricTags = Record<string, string>;
+
+export interface TelemetryContext {
+  requestId: string;
+  updateId?: number;
+  chatId?: number;
+  userId?: string;
+  messageType?: MessageType;
+  jobId?: string;
+  component?: string;
+  stage?: string;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,11 @@
 // src/server.ts — Express setup, webhook registration, graceful shutdown
 import express, { Request, Response, NextFunction } from 'express';
-import { logger } from './utils/logger';
+import {
+  getMetricsContentType,
+  getMetricsSnapshot,
+  recordUncaughtError,
+} from './observability';
+import { logger, serializeError } from './utils/logger';
 import { createWebhookRouter } from './controllers/webhook.controller';
 import { botService } from './app';
 
@@ -12,7 +17,7 @@ const TELEGRAM_SECRET_TOKEN = process.env.TELEGRAM_SECRET_TOKEN!;
   try {
     await botService.setupWebhook(NGROK_URL, TELEGRAM_SECRET_TOKEN);
   } catch (err) {
-    logger.error('Error setting up webhook:', err);
+    logger.error('app.webhook_setup_failed', serializeError(err));
   }
 })();
 
@@ -24,17 +29,43 @@ app.get('/ping', (_req: Request, res: Response, _next: NextFunction) => {
   res.json({ status: 'ok' });
 });
 
+app.get('/metrics', async (_req: Request, res: Response) => {
+  res.setHeader('Content-Type', getMetricsContentType());
+  res.send(await getMetricsSnapshot());
+});
+
 app.use(createWebhookRouter(botService));
 
 // Start listening
 const PORT = process.env.PORT || 3000;
+logger.info('app.starting', { port: PORT });
 app.listen(PORT, () => {
-  logger.info(`Server started at http://localhost:${PORT}`);
-  logger.info(`Waiting for Telegram updates on /webhook/:secret`);
+  logger.info('app.ready', {
+    port: PORT,
+    healthPath: '/ping',
+    metricsPath: '/metrics',
+  });
 });
 
 // Graceful shutdown
 process.on('SIGTERM', () => {
-  logger.info('Shutting down gracefully...');
+  logger.info('app.shutting_down', { signal: 'SIGTERM' });
   process.exit(0);
+});
+
+process.on('uncaughtException', (error) => {
+  recordUncaughtError('uncaughtException');
+  logger.error('runtime.fatal', {
+    kind: 'uncaughtException',
+    ...serializeError(error),
+  });
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (reason) => {
+  recordUncaughtError('unhandledRejection');
+  logger.error('runtime.fatal', {
+    kind: 'unhandledRejection',
+    ...serializeError(reason),
+  });
 });

--- a/src/services/ai/gpt.service.ts
+++ b/src/services/ai/gpt.service.ts
@@ -12,8 +12,14 @@
  */
 
 import OpenAI from 'openai';
-import { logger } from '../../utils/logger';
 import { ToolDispatcher } from '../../types/tool.types';
+import {
+  TelemetryContext,
+  estimateOpenAICostUsd,
+  extendTelemetryContext,
+  recordOpenAIRequest,
+} from '../../observability';
+import { getLogger, serializeError } from '../../utils/logger';
 
 // Import modularized components
 import { GPT_CONSTANTS } from './constants/gpt.constants';
@@ -63,7 +69,7 @@ export class GPTService {
     this.functionCallingProcessor = new FunctionCallingProcessor(toolDispatcher);
     this.simpleTextProcessor = new SimpleTextProcessor();
 
-    logger.info('GPTService initialized', {
+    getLogger({ requestId: 'startup', component: 'gpt_service' }).info('openai.service.initialized', {
       model: this.config.model,
       maxInputLength: this.config.maxInputLength,
       temperature: this.config.temperature,
@@ -78,13 +84,24 @@ export class GPTService {
    * @param userId - User identifier for context/authorization
    * @returns Promise<string> - The final response to send back to user
    */
-  async processMessage(message: string, userId?: string): Promise<string> {
+  async processMessage(
+    message: string,
+    userId?: string,
+    context?: TelemetryContext,
+  ): Promise<string> {
     const startTime = Date.now();
-
-    logger.info('Processing message with GPT', {
+    const scopedContext = extendTelemetryContext(context, {
+      component: 'gpt_service',
       userId,
+      stage: 'openai_chat',
+    });
+    const logger = getLogger(scopedContext);
+
+    logger.info('openai.chat.requested', {
       messageLength: message.length,
       functionCallingEnabled: this.enableFunctionCalling,
+      operation: this.enableFunctionCalling ? 'function_calling' : 'simple_text',
+      model: this.config.model,
     });
 
     const MAX_RETRIES = 3;
@@ -103,28 +120,68 @@ export class GPTService {
             this.config.temperature,
             message,
             userId || 'anonymous',
+            scopedContext,
           );
+          const durationMs = Date.now() - startTime;
+          recordOpenAIRequest(
+            { model: this.config.model, operation: 'function_calling', status: 'success' },
+            durationMs,
+            result.usage,
+          );
+          logger.info('openai.chat.succeeded', {
+            model: this.config.model,
+            durationMs,
+            operation: 'function_calling',
+            promptTokens: result.usage?.promptTokens,
+            completionTokens: result.usage?.completionTokens,
+            totalTokens: result.usage?.totalTokens,
+            estimatedCostUsd: estimateOpenAICostUsd({
+              model: this.config.model,
+              promptTokens: result.usage?.promptTokens,
+              completionTokens: result.usage?.completionTokens,
+            }),
+          });
           return result.response;
         }
 
         // Fallback to simple text generation
-        return await this.simpleTextProcessor.processSimpleMessage(
+        const result = await this.simpleTextProcessor.processSimpleMessage(
           this.openai,
           this.config.model,
           this.config.temperature,
           message,
           userId,
+          scopedContext,
         );
+        const durationMs = Date.now() - startTime;
+        recordOpenAIRequest(
+          { model: this.config.model, operation: 'simple_text', status: 'success' },
+          durationMs,
+          result.usage,
+        );
+        logger.info('openai.chat.succeeded', {
+          model: this.config.model,
+          durationMs,
+          operation: 'simple_text',
+          promptTokens: result.usage?.promptTokens,
+          completionTokens: result.usage?.completionTokens,
+          totalTokens: result.usage?.totalTokens,
+          estimatedCostUsd: estimateOpenAICostUsd({
+            model: this.config.model,
+            promptTokens: result.usage?.promptTokens,
+            completionTokens: result.usage?.completionTokens,
+          }),
+        });
+        return result.response;
       } catch (error) {
         lastError = error as Error;
 
         if (attempt < MAX_RETRIES && GPTErrorHandler.isRetryableError(lastError)) {
           const delay = GPTErrorHandler.getRetryDelay(attempt);
-          logger.warn('Retryable error encountered, retrying', {
-            userId,
+          logger.warn('openai.chat.retry_scheduled', {
             attempt,
             delayMs: delay,
-            error: lastError.message,
+            ...serializeError(lastError),
           });
           await new Promise((resolve) => setTimeout(resolve, delay));
           continue;
@@ -136,12 +193,20 @@ export class GPTService {
 
     const processingTimeMs = Date.now() - startTime;
 
-    logger.error('Message processing failed', {
-      userId,
+    logger.error('openai.chat.failed', {
       messageLength: message.length,
-      error: lastError!.message,
       processingTimeMs,
+      model: this.config.model,
+      ...serializeError(lastError),
     });
+    recordOpenAIRequest(
+      {
+        model: this.config.model,
+        operation: this.enableFunctionCalling ? 'function_calling' : 'simple_text',
+        status: 'error',
+      },
+      processingTimeMs,
+    );
 
     return GPTErrorHandler.handleProcessingError(lastError!);
   }

--- a/src/services/ai/processors/function-calling.processor.ts
+++ b/src/services/ai/processors/function-calling.processor.ts
@@ -5,7 +5,8 @@
  */
 
 import OpenAI from 'openai';
-import { logger } from '../../../utils/logger';
+import { TelemetryContext, extendTelemetryContext } from '../../../observability';
+import { getLogger, serializeError } from '../../../utils/logger';
 import { MessageProcessingResult } from '../../../types/gpt.types';
 import { GPT_CONSTANTS } from '../constants/gpt.constants';
 import { getFunctionCallingSystemPrompt, FINAL_RESPONSE_PROMPT } from '../../../types/gpt.prompts';
@@ -38,8 +39,15 @@ export class FunctionCallingProcessor {
     temperature: number,
     message: string,
     userId: string,
+    context?: TelemetryContext,
   ): Promise<MessageProcessingResult> {
     const startTime = Date.now();
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        component: 'function_calling_processor',
+        userId,
+      }),
+    );
 
     try {
       // Send message to GPT with function calling capabilities enabled
@@ -64,11 +72,10 @@ export class FunctionCallingProcessor {
       const responseMessage = response.choices[0].message;
 
       // Log the full GPT response for inspection
-      logger.debug('GPT function calling response', {
-        userId,
+      logger.debug('openai.chat.succeeded', {
         hasToolCalls: !!(responseMessage.tool_calls && responseMessage.tool_calls.length > 0),
         toolCallsCount: responseMessage.tool_calls?.length || 0,
-        content: responseMessage.content,
+        hasContent: !!responseMessage.content,
       });
 
       // Check if GPT wants to call any functions
@@ -80,6 +87,7 @@ export class FunctionCallingProcessor {
           temperature,
           message,
           userId,
+          context,
         );
 
         return {
@@ -89,6 +97,11 @@ export class FunctionCallingProcessor {
           usedFunctionCalling: true,
           functionCallsCount: responseMessage.tool_calls.length,
           model,
+          usage: {
+            promptTokens: response.usage?.prompt_tokens,
+            completionTokens: response.usage?.completion_tokens,
+            totalTokens: response.usage?.total_tokens,
+          },
         };
       }
 
@@ -103,12 +116,14 @@ export class FunctionCallingProcessor {
         usedFunctionCalling: false,
         functionCallsCount: 0,
         model,
+        usage: {
+          promptTokens: response.usage?.prompt_tokens,
+          completionTokens: response.usage?.completion_tokens,
+          totalTokens: response.usage?.total_tokens,
+        },
       };
     } catch (error) {
-      logger.error('Function calling processing failed', {
-        userId,
-        error: (error as Error).message,
-      });
+      logger.error('openai.chat.failed', serializeError(error));
 
       throw error;
     }
@@ -132,7 +147,15 @@ export class FunctionCallingProcessor {
     temperature: number,
     originalMessage: string,
     userId: string,
+    context?: TelemetryContext,
   ): Promise<string> {
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        component: 'tool_dispatch',
+        userId,
+        stage: 'dispatch',
+      }),
+    );
     if (!this.toolDispatcher || !responseMessage.tool_calls) {
       return "I'd like to help you with that, but I'm currently unable to execute the required actions.";
     }
@@ -148,8 +171,7 @@ export class FunctionCallingProcessor {
         },
       }));
 
-      logger.info('Executing tool calls', {
-        userId,
+      logger.info('tool.dispatch.started', {
         toolCalls: toolCalls.map((tc) => ({
           id: tc.id,
           name: tc.function.name,
@@ -159,7 +181,7 @@ export class FunctionCallingProcessor {
       // Filter out any function names the dispatcher does not support
       const supportedCalls = toolCalls.filter((tc) => {
         if (this.toolDispatcher!.isFunctionSupported(tc.function.name)) return true;
-        logger.warn('Skipping unsupported function', { name: tc.function.name, userId });
+        logger.warn('tool.call.failed', { name: tc.function.name, reason: 'unsupported_function' });
         return false;
       });
 
@@ -168,11 +190,10 @@ export class FunctionCallingProcessor {
       }
 
       // Execute all supported tool calls
-      const toolResults = await this.toolDispatcher.executeToolCalls(supportedCalls, userId);
+      const toolResults = await this.toolDispatcher.executeToolCalls(supportedCalls, userId, context);
 
       // Log execution results
-      logger.info('Tool execution completed', {
-        userId,
+      logger.info('tool.dispatch.completed', {
         results: toolResults.map((result) => ({
           tool_call_id: result.tool_call_id,
           success: !result.error,
@@ -192,10 +213,7 @@ export class FunctionCallingProcessor {
 
       return finalResponse;
     } catch (error) {
-      logger.error('Tool call execution failed', {
-        userId,
-        error: (error as Error).message,
-      });
+      logger.error('tool.dispatch.failed', serializeError(error));
 
       return `I encountered an error while trying to help you: ${(error as Error).message}. Please try again or rephrase your request.`;
     }
@@ -259,9 +277,10 @@ export class FunctionCallingProcessor {
         'I completed the requested actions successfully.'
       );
     } catch (error) {
-      logger.error('Failed to generate final response', {
-        error: (error as Error).message,
-      });
+      getLogger({ requestId: 'tool-response', component: 'tool_dispatch' }).error(
+        'openai.chat.failed',
+        serializeError(error),
+      );
 
       // Fallback: create a simple response based on results
       const successfulActions = toolResults.filter((result) => !result.error);

--- a/src/services/ai/processors/simple-text.processor.ts
+++ b/src/services/ai/processors/simple-text.processor.ts
@@ -5,9 +5,11 @@
  */
 
 import OpenAI from 'openai';
-import { logger } from '../../../utils/logger';
+import { TelemetryContext, extendTelemetryContext } from '../../../observability';
+import { getLogger, serializeError } from '../../../utils/logger';
 import { GPT_CONSTANTS } from '../constants/gpt.constants';
 import { SIMPLE_CONVERSATION_PROMPT } from '../../../types/gpt.prompts';
+import { MessageProcessingResult } from '../../../types/gpt.types';
 
 /**
  * Processor for handling simple text generation without function calling
@@ -21,7 +23,7 @@ export class SimpleTextProcessor {
    * @param temperature - Temperature setting for the model
    * @param message - User message
    * @param userId - User ID (optional)
-   * @returns Promise<string> - Generated response
+   * @returns Promise<MessageProcessingResult> - Generated response and usage
    */
   async processSimpleMessage(
     openai: OpenAI,
@@ -29,7 +31,14 @@ export class SimpleTextProcessor {
     temperature: number,
     message: string,
     userId?: string,
-  ): Promise<string> {
+    context?: TelemetryContext,
+  ): Promise<MessageProcessingResult> {
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        component: 'simple_text_processor',
+        userId,
+      }),
+    );
     try {
       const completion = await openai.chat.completions.create({
         model,
@@ -47,15 +56,23 @@ export class SimpleTextProcessor {
         temperature,
       });
 
-      return (
-        completion.choices[0]?.message?.content ||
-        "I apologize, but I couldn't generate a response."
-      );
+      return {
+        response:
+          completion.choices[0]?.message?.content ||
+          "I apologize, but I couldn't generate a response.",
+        originalMessage: message,
+        processingTimeMs: 0,
+        usedFunctionCalling: false,
+        functionCallsCount: 0,
+        model,
+        usage: {
+          promptTokens: completion.usage?.prompt_tokens,
+          completionTokens: completion.usage?.completion_tokens,
+          totalTokens: completion.usage?.total_tokens,
+        },
+      };
     } catch (error) {
-      logger.error('Simple message processing failed', {
-        userId,
-        error: (error as Error).message,
-      });
+      logger.error('openai.chat.failed', serializeError(error));
 
       throw error;
     }

--- a/src/services/ai/whisper.service.ts
+++ b/src/services/ai/whisper.service.ts
@@ -12,7 +12,13 @@
  */
 
 import OpenAI from 'openai';
-import { logger } from '../../utils/logger';
+import {
+  TelemetryContext,
+  extendTelemetryContext,
+  hashContent,
+  recordWhisperRequest,
+} from '../../observability';
+import { getLogger, serializeError } from '../../utils/logger';
 import { AudioMimeTypes } from '../../utils/constants';
 import { validateFileSize } from '../../utils/ai/fileValidation';
 import { AudioConverter } from '../../utils/ai/audioConverter';
@@ -106,7 +112,7 @@ export class WhisperService {
       ? WHISPER_CONSTANTS.DEFAULT_LANGUAGE
       : config?.language || WHISPER_CONSTANTS.DEFAULT_LANGUAGE;
 
-    logger.info('WhisperService initialized', {
+    getLogger({ requestId: 'startup', component: 'whisper_service' }).info('audio.service.initialized', {
       model: this.config.model,
       maxFileSizeMB: Math.round(this.config.maxFileSizeBytes / (1024 * 1024)),
       responseFormat: this.config.responseFormat,
@@ -123,17 +129,26 @@ export class WhisperService {
    * @returns Promise resolving to transcription result
    * @throws {Error} If file download fails, file is too large, or transcription fails
    */
-  async transcribeAudio(fileUrl: string, userId?: number): Promise<TranscriptionResult> {
+  async transcribeAudio(
+    fileUrl: string,
+    userId?: number,
+    context?: TelemetryContext,
+  ): Promise<TranscriptionResult> {
     const startTime = Date.now();
+    const scopedContext = extendTelemetryContext(context, {
+      component: 'whisper_service',
+      userId: userId ? String(userId) : undefined,
+      stage: 'transcription',
+    });
+    const logger = getLogger(scopedContext);
 
-    logger.info('Starting audio transcription', {
-      userId,
-      fileUrl: this.sanitizeUrlForLogging(fileUrl),
+    logger.info('audio.transcription.started', {
+      fileUrlHash: hashContent(fileUrl),
     });
 
     try {
       // Download the audio file
-      const audioBuffer = await this.downloadAudioFile(fileUrl);
+      const audioBuffer = await this.downloadAudioFile(fileUrl, scopedContext);
 
       // Validate file size
       validateFileSize(audioBuffer.length, this.config.maxFileSizeBytes);
@@ -147,8 +162,7 @@ export class WhisperService {
       let conversionTimeMs = 0;
 
       if (AudioConverter.needsConversion(originalExtension)) {
-        logger.info('Audio format needs conversion', {
-          userId,
+        logger.info('audio.conversion.started', {
           originalFormat: originalExtension,
           targetFormat: AudioConverter.getTargetFormat(),
         });
@@ -158,6 +172,7 @@ export class WhisperService {
             audioBuffer,
             originalExtension,
             userId,
+            scopedContext,
           );
 
           processedBuffer = conversionResult.convertedBuffer;
@@ -167,8 +182,7 @@ export class WhisperService {
           // Validate converted file size
           validateFileSize(processedBuffer.length, this.config.maxFileSizeBytes);
 
-          logger.info('Audio conversion completed', {
-            userId,
+          logger.info('audio.conversion.succeeded', {
             originalFormat: originalExtension,
             targetFormat: fileExtension,
             originalSize: audioBuffer.length,
@@ -176,10 +190,9 @@ export class WhisperService {
             conversionTimeMs,
           });
         } catch (conversionError) {
-          logger.error('Audio conversion failed', {
-            userId,
+          logger.error('audio.conversion.failed', {
             originalFormat: originalExtension,
-            error: (conversionError as Error).message,
+            ...serializeError(conversionError),
           });
 
           // Provide helpful error message for conversion failures
@@ -201,7 +214,7 @@ export class WhisperService {
       });
 
       // Perform transcription
-      const transcription = await this.performTranscription(audioFile);
+      const transcription = await this.performTranscription(audioFile, scopedContext);
 
       const processingTimeMs = Date.now() - startTime;
 
@@ -214,8 +227,7 @@ export class WhisperService {
 
       // Add conversion information to logs if conversion was performed
       const logData: any = {
-        userId,
-        text: result.text.substring(0, WHISPER_CONSTANTS.MAX_LOG_TEXT_LENGTH),
+        textHash: hashContent(result.text.substring(0, WHISPER_CONSTANTS.MAX_LOG_TEXT_LENGTH)),
         textLength: transcription.length,
         processingTimeMs,
         fileSizeBytes: processedBuffer.length,
@@ -228,18 +240,19 @@ export class WhisperService {
         logData.transcriptionTimeMs = processingTimeMs - conversionTimeMs;
       }
 
-      logger.info('Audio transcription completed successfully', logData);
+      logger.info('audio.transcription.succeeded', logData);
+      recordWhisperRequest('success', processingTimeMs);
 
       return result;
     } catch (error) {
       const processingTimeMs = Date.now() - startTime;
 
-      logger.error('Audio transcription failed', {
-        userId,
-        fileUrl: this.sanitizeUrlForLogging(fileUrl),
-        error: (error as Error).message,
+      logger.error('audio.transcription.failed', {
+        fileUrlHash: hashContent(fileUrl),
+        ...serializeError(error),
         processingTimeMs,
       });
+      recordWhisperRequest('error', processingTimeMs);
 
       throw new Error(`Transcription failed: ${(error as Error).message}`);
     }
@@ -252,8 +265,10 @@ export class WhisperService {
    * @returns Promise resolving to audio file buffer
    * @private
    */
-  private async downloadAudioFile(fileUrl: string): Promise<Buffer> {
+  private async downloadAudioFile(fileUrl: string, context?: TelemetryContext): Promise<Buffer> {
+    const logger = getLogger(extendTelemetryContext(context, { component: 'whisper_download' }));
     try {
+      logger.info('audio.download.started', { fileUrlHash: hashContent(fileUrl) });
       const response = await fetch(fileUrl);
 
       if (!response.ok) {
@@ -263,12 +278,16 @@ export class WhisperService {
       // Validate content type if available
       const contentType = response.headers.get('content-type');
       if (contentType && !this.isValidAudioMimeType(contentType)) {
-        logger.warn('Unexpected content type for audio file', { contentType });
+        logger.warn('audio.download.unexpected_content_type', { contentType });
       }
 
       const arrayBuffer = await response.arrayBuffer();
       return Buffer.from(arrayBuffer);
     } catch (error) {
+      logger.error('audio.download.failed', {
+        fileUrlHash: hashContent(fileUrl),
+        ...serializeError(error),
+      });
       throw new Error(`Failed to download audio file: ${(error as Error).message}`);
     }
   }
@@ -280,7 +299,8 @@ export class WhisperService {
    * @returns Promise resolving to transcribed text
    * @private
    */
-  private async performTranscription(audioFile: File): Promise<string> {
+  private async performTranscription(audioFile: File, context?: TelemetryContext): Promise<string> {
+    const logger = getLogger(extendTelemetryContext(context, { component: 'whisper_api' }));
     try {
       const transcription = await this.openai.audio.transcriptions.create({
         file: audioFile,
@@ -304,6 +324,7 @@ export class WhisperService {
 
       return transcribedText;
     } catch (error) {
+      logger.error('audio.transcription.failed', serializeError(error));
       if (error instanceof Error) {
         // Handle specific OpenAI API errors
         if (error.message.includes('Invalid file format')) {
@@ -326,6 +347,7 @@ export class WhisperService {
    * @private
    */
   private validateEnglishContent(text: string): void {
+    const logger = getLogger({ requestId: 'whisper-validation', component: 'whisper_service' });
     // Basic heuristic to detect potential non-English content
     const nonLatinChars = /[^\x00-\x7F\s\p{P}]/u.test(text);
     const commonNonEnglishPatterns =
@@ -335,7 +357,7 @@ export class WhisperService {
 
     if (nonLatinChars || commonNonEnglishPatterns) {
       logger.warn('Potential non-English content detected in transcription', {
-        textSample: text.substring(0, 50),
+        textSampleHash: hashContent(text.substring(0, 50)),
         hasNonLatinChars: nonLatinChars,
         hasNonEnglishPatterns: commonNonEnglishPatterns,
         enforceEnglishOnly: this.config.enforceEnglishOnly,

--- a/src/services/external/todoist-api.service.ts
+++ b/src/services/external/todoist-api.service.ts
@@ -4,8 +4,8 @@
  *
  * @module TodoistAPIService
  */
-
-import { logger } from '../../utils/logger';
+import { extendTelemetryContext, getTelemetryContext } from '../../observability';
+import { createComponentLogger, serializeError } from '../../utils/logger';
 
 /**
  * Todoist API response interfaces
@@ -102,6 +102,10 @@ export class TodoistAPIService {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' = 'GET',
     body?: any,
   ): Promise<any> {
+    const logger = createComponentLogger(
+      'todoist_api',
+      extendTelemetryContext(getTelemetryContext(), { stage: 'todoist_request' }),
+    );
     const url = `${this.baseURL}${endpoint}`;
 
     const headers: Record<string, string> = {
@@ -119,7 +123,7 @@ export class TodoistAPIService {
     }
 
     try {
-      logger.debug('Making Todoist API request', {
+      logger.debug('todoist.request.started', {
         url,
         method,
         hasBody: !!body,
@@ -139,7 +143,7 @@ export class TodoistAPIService {
 
       const data = await response.json();
 
-      logger.debug('Todoist API response received', {
+      logger.debug('todoist.request.succeeded', {
         url,
         status: response.status,
         hasData: !!data,
@@ -147,10 +151,10 @@ export class TodoistAPIService {
 
       return data;
     } catch (error) {
-      logger.error('Todoist API request failed', {
+      logger.error('todoist.request.failed', {
         url,
         method,
-        error: (error as Error).message,
+        ...serializeError(error),
       });
       throw error;
     }
@@ -163,7 +167,8 @@ export class TodoistAPIService {
    * @returns Promise<TodoistTask> - Created task
    */
   async addTask(payload: CreateTaskPayload): Promise<TodoistTask> {
-    logger.info('Creating Todoist task', {
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.info('todoist.task.create.started', {
       content: payload.content,
       priority: payload.priority,
       hasDescription: !!payload.description,
@@ -171,7 +176,7 @@ export class TodoistAPIService {
 
     const task = await this.makeRequest('/tasks', 'POST', payload);
 
-    logger.info('Todoist task created successfully', {
+    logger.info('todoist.task.create.succeeded', {
       taskId: task.id,
       content: task.content,
     });
@@ -186,11 +191,12 @@ export class TodoistAPIService {
    * @returns Promise<TodoistTask> - Task details
    */
   async getTask(taskId: string): Promise<TodoistTask> {
-    logger.debug('Fetching Todoist task', { taskId });
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.debug('todoist.task.fetch.started', { taskId });
 
     const task = await this.makeRequest(`/tasks/${taskId}`);
 
-    logger.debug('Todoist task retrieved', {
+    logger.debug('todoist.task.fetch.succeeded', {
       taskId: task.id,
       content: task.content,
     });
@@ -214,7 +220,8 @@ export class TodoistAPIService {
       ids?: string[];
     } = {},
   ): Promise<TodoistTask[]> {
-    logger.debug('Fetching Todoist tasks', options);
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.debug('todoist.tasks.fetch.started', options);
 
     const params = new URLSearchParams();
 
@@ -230,7 +237,7 @@ export class TodoistAPIService {
     const endpoint = `/tasks${params.toString() ? '?' + params.toString() : ''}`;
     const tasks = await this.makeRequest(endpoint);
 
-    logger.debug('Todoist tasks retrieved', {
+    logger.debug('todoist.tasks.fetch.succeeded', {
       count: tasks.length,
       filter: options.filter,
     });
@@ -246,7 +253,8 @@ export class TodoistAPIService {
    * @returns Promise<TodoistTask> - Updated task
    */
   async updateTask(taskId: string, payload: UpdateTaskPayload): Promise<TodoistTask> {
-    logger.info('Updating Todoist task', {
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.info('todoist.task.update.started', {
       taskId,
       hasContent: !!payload.content,
       priority: payload.priority,
@@ -254,7 +262,7 @@ export class TodoistAPIService {
 
     const task = await this.makeRequest(`/tasks/${taskId}`, 'PUT', payload);
 
-    logger.info('Todoist task updated successfully', {
+    logger.info('todoist.task.update.succeeded', {
       taskId: task.id,
       content: task.content,
     });
@@ -269,11 +277,12 @@ export class TodoistAPIService {
    * @returns Promise<void>
    */
   async completeTask(taskId: string): Promise<void> {
-    logger.info('Completing Todoist task', { taskId });
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.info('todoist.task.complete.started', { taskId });
 
     await this.makeRequest(`/tasks/${taskId}/close`, 'POST');
 
-    logger.info('Todoist task completed successfully', { taskId });
+    logger.info('todoist.task.complete.succeeded', { taskId });
   }
 
   /**
@@ -283,11 +292,12 @@ export class TodoistAPIService {
    * @returns Promise<void>
    */
   async deleteTask(taskId: string): Promise<void> {
-    logger.info('Deleting Todoist task', { taskId });
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.info('todoist.task.delete.started', { taskId });
 
     await this.makeRequest(`/tasks/${taskId}`, 'DELETE');
 
-    logger.info('Todoist task deleted successfully', { taskId });
+    logger.info('todoist.task.delete.succeeded', { taskId });
   }
 
   /**
@@ -296,11 +306,12 @@ export class TodoistAPIService {
    * @returns Promise<TodoistProject[]> - Array of projects
    */
   async getProjects(): Promise<TodoistProject[]> {
-    logger.debug('Fetching Todoist projects');
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.debug('todoist.projects.fetch.started');
 
     const projects = await this.makeRequest('/projects');
 
-    logger.debug('Todoist projects retrieved', {
+    logger.debug('todoist.projects.fetch.succeeded', {
       count: projects.length,
     });
 
@@ -338,7 +349,8 @@ export class TodoistAPIService {
       offset?: number;
     } = {},
   ): Promise<any[]> {
-    logger.debug('Fetching completed Todoist tasks', options);
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.debug('todoist.completed_tasks.fetch.started', options);
 
     // Note: This uses the Sync API endpoint for completed tasks
     const syncUrl = 'https://api.todoist.com/sync/v9/completed/get_all';
@@ -367,15 +379,13 @@ export class TodoistAPIService {
 
       const data = await response.json();
 
-      logger.debug('Completed Todoist tasks retrieved', {
+      logger.debug('todoist.completed_tasks.fetch.succeeded', {
         count: data.items?.length || 0,
       });
 
       return data.items || [];
     } catch (error) {
-      logger.error('Failed to fetch completed tasks', {
-        error: (error as Error).message,
-      });
+      logger.error('todoist.completed_tasks.fetch.failed', serializeError(error));
       throw error;
     }
   }

--- a/src/services/telegram/file.service.ts
+++ b/src/services/telegram/file.service.ts
@@ -1,5 +1,6 @@
 // src/services/telegram/file.service.ts
-import { logger } from '../../utils/logger';
+import { extendTelemetryContext, getTelemetryContext } from '../../observability';
+import { createComponentLogger, serializeError } from '../../utils/logger';
 import { Telegram } from 'telegraf';
 import { AudioMimeTypes } from '../../utils/constants';
 
@@ -24,6 +25,10 @@ export class FileService {
    * Gets the download URL for a file from Telegram
    */
   async getFileUrl(fileId: string): Promise<string> {
+    const logger = createComponentLogger(
+      'telegram_file',
+      extendTelemetryContext(getTelemetryContext(), { stage: 'file_url' }),
+    );
     try {
       const file = await this.telegram.getFile(fileId);
       if (!file.file_path) {
@@ -31,9 +36,9 @@ export class FileService {
       }
       return `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
     } catch (error) {
-      logger.error('Error getting file URL', {
-        error: (error as Error).message,
-        fileId
+      logger.error('audio.download.failed', {
+        fileId,
+        ...serializeError(error),
       });
       throw new Error(`Failed to get file URL: ${(error as Error).message}`);
     }
@@ -43,6 +48,10 @@ export class FileService {
    * Downloads a file from Telegram
    */
   async downloadFile(fileId: string): Promise<Buffer> {
+    const logger = createComponentLogger(
+      'telegram_file',
+      extendTelemetryContext(getTelemetryContext(), { stage: 'download' }),
+    );
     try {
       const fileUrl = await this.getFileUrl(fileId);
       const response = await fetch(fileUrl);
@@ -53,9 +62,9 @@ export class FileService {
 
       return Buffer.from(await response.arrayBuffer());
     } catch (error) {
-      logger.error('Error downloading file', {
-        error: (error as Error).message,
-        fileId
+      logger.error('audio.download.failed', {
+        fileId,
+        ...serializeError(error),
       });
       throw error;
     }

--- a/src/services/telegram/handlers/command-handlers.ts
+++ b/src/services/telegram/handlers/command-handlers.ts
@@ -1,6 +1,7 @@
 // src/services/telegram/handlers/command-handlers.ts
 import { Context } from 'telegraf';
-import { logger } from '../../../utils/logger';
+import { extendTelemetryContext, getTelemetryContext } from '../../../observability';
+import { getLogger } from '../../../utils/logger';
 import { BotActivityService } from '../bot-activity.service';
 import { BotStatusService } from '../bot-status.service';
 
@@ -15,7 +16,15 @@ export class CommandHandlers {
 
   async handleHelp(ctx: Context): Promise<void> {
     const userId = ctx.from?.id;
-    logger.info('User requested help', { userId });
+    const logger = getLogger(
+      extendTelemetryContext(getTelemetryContext(), {
+        component: 'telegram_command',
+        chatId: ctx.chat?.id,
+        userId: userId ? String(userId) : undefined,
+        messageType: 'command',
+      }),
+    );
+    logger.info('telegram.command.received', { command: 'help' });
     this.activityService.recordActivity('command_help');
 
     const helpMessage = `🆘 *JarvisMCP Help*
@@ -40,7 +49,15 @@ export class CommandHandlers {
 
   async handleStatus(ctx: Context): Promise<void> {
     const userId = ctx.from?.id;
-    logger.info('User requested status', { userId });
+    const logger = getLogger(
+      extendTelemetryContext(getTelemetryContext(), {
+        component: 'telegram_command',
+        chatId: ctx.chat?.id,
+        userId: userId ? String(userId) : undefined,
+        messageType: 'command',
+      }),
+    );
+    logger.info('telegram.command.received', { command: 'status' });
     this.activityService.recordActivity('command_status');
 
     const statusMessage = await this.statusService.getFormattedStatus();

--- a/src/services/telegram/handlers/message-handlers.ts
+++ b/src/services/telegram/handlers/message-handlers.ts
@@ -1,6 +1,10 @@
 // src/services/telegram/handlers/message-handlers.ts
 import { Context } from 'telegraf';
-import { logger } from '../../../utils/logger';
+import {
+  extendTelemetryContext,
+  getTelemetryContext,
+} from '../../../observability';
+import { getLogger, serializeError } from '../../../utils/logger';
 import { FileService } from '../file.service';
 import { MessageProcessorService } from '../message-processor.service';
 import { BotActivityService } from '../bot-activity.service';
@@ -20,21 +24,28 @@ export class MessageHandlers {
 
     const messageText = ctx.message.text;
     const userId = ctx.from?.id;
+    const context = extendTelemetryContext(getTelemetryContext(), {
+      component: 'telegram_message',
+      chatId: ctx.chat?.id,
+      userId: userId ? String(userId) : undefined,
+      messageType: 'text',
+      stage: 'received',
+    });
+    const logger = getLogger(context);
 
-    logger.info('Received text message', {
-      userId,
+    logger.info('telegram.message.received', {
       username: ctx.from?.username,
-      messageLength: messageText.length
+      messageLength: messageText.length,
     });
     this.activityService.recordActivity('message_text');
 
     try {
-      const response = await this.messageProcessor.processTextMessage(messageText, userId);
+      const response = await this.messageProcessor.processTextMessage(messageText, userId, context);
       await ctx.reply(response);
+      logger.info('telegram.reply.sent', { replyLength: response.length });
     } catch (error) {
-      logger.error('Error processing text message', {
-        error: (error as Error).message,
-        userId
+      logger.error('message.route.failed', {
+        ...serializeError(error),
       });
       await ctx.reply('❌ Sorry, I had trouble processing your message.');
     }
@@ -45,23 +56,28 @@ export class MessageHandlers {
 
     const voice = ctx.message.voice;
     const userId = ctx.from?.id;
+    const context = extendTelemetryContext(getTelemetryContext(), {
+      component: 'telegram_message',
+      chatId: ctx.chat?.id,
+      userId: userId ? String(userId) : undefined,
+      messageType: 'audio',
+      stage: 'received',
+    });
+    const logger = getLogger(context);
 
-    logger.info('Voice message received', {
-      userId,
+    logger.info('telegram.message.received', {
       duration: voice.duration,
-      fileSize: voice.file_size
+      fileSize: voice.file_size,
     });
     this.activityService.recordActivity('message_voice');
 
     try {
       const fileUrl = await this.fileService.getFileUrl(voice.file_id);
-      const response = await this.messageProcessor.processAudioMessage(fileUrl, userId);
+      const response = await this.messageProcessor.processAudioMessage(fileUrl, userId, context);
       await ctx.reply(response);
+      logger.info('telegram.reply.sent', { replyLength: response.length });
     } catch (error) {
-      logger.error('Error processing voice message', {
-        error: (error as Error).message,
-        userId
-      });
+      logger.error('message.route.failed', serializeError(error));
       await ctx.reply('❌ Sorry, I had trouble processing your voice message.');
     }
   }
@@ -79,14 +95,21 @@ export class MessageHandlers {
 
     const document = ctx.message.document;
     const userId = ctx.from?.id;
+    const context = extendTelemetryContext(getTelemetryContext(), {
+      component: 'telegram_message',
+      chatId: ctx.chat?.id,
+      userId: userId ? String(userId) : undefined,
+      messageType: 'audio_document',
+      stage: 'received',
+    });
+    const logger = getLogger(context);
 
     if (this.fileService.isAudioFile(document.mime_type)) {
       this.activityService.recordActivity('message_document');
       const fileName = document.file_name || 'audio_file';
       const mimeType = document.mime_type || 'application/octet-stream';
 
-      logger.info('Audio document received', {
-        userId,
+      logger.info('telegram.message.received', {
         fileName,
         mimeType,
         fileSize: document.file_size,
@@ -99,21 +122,21 @@ export class MessageHandlers {
           fileName,
           mimeType,
           userId,
+          context,
         );
         await ctx.reply(response);
+        logger.info('telegram.reply.sent', { replyLength: response.length });
       } catch (error) {
-        logger.error('Error processing audio document', {
-          error: (error as Error).message,
-          userId,
+        logger.error('message.route.failed', {
+          ...serializeError(error),
           fileName,
         });
         await ctx.reply('❌ Sorry, I had trouble processing your audio document.');
       }
     } else {
-      logger.info('Non-audio document received', {
-        userId,
+      logger.info('telegram.message.received', {
         mimeType: document.mime_type,
-        fileName: document.file_name
+        fileName: document.file_name,
       });
       await ctx.reply('📄 I received a document, but I only process audio files. Please send an audio file.');
     }
@@ -121,11 +144,16 @@ export class MessageHandlers {
 
   async handleUnknown(ctx: Context): Promise<void> {
     const userId = ctx.from?.id;
-
-    logger.info('Unhandled message type received', {
-      userId,
-      messageType: 'unknown'
+    const context = extendTelemetryContext(getTelemetryContext(), {
+      component: 'telegram_message',
+      chatId: ctx.chat?.id,
+      userId: userId ? String(userId) : undefined,
+      messageType: 'unknown',
+      stage: 'received',
     });
+    const logger = getLogger(context);
+
+    logger.info('telegram.message.received', { messageType: 'unknown' });
     this.activityService.recordActivity('message_unknown');
 
     await ctx.reply(
@@ -137,23 +165,30 @@ export class MessageHandlers {
     const userId = ctx.from?.id;
     const fileName = audioFile.file_name || 'audio_file';
     const mimeType = audioFile.mime_type;
+    const context = extendTelemetryContext(getTelemetryContext(), {
+      component: 'telegram_message',
+      chatId: ctx.chat?.id,
+      userId: userId ? String(userId) : undefined,
+      messageType: 'audio',
+      stage: 'received',
+    });
+    const logger = getLogger(context);
 
-    logger.info('Audio file received', {
-      userId,
+    logger.info('telegram.message.received', {
       fileName,
       mimeType,
       fileSize: audioFile.file_size,
-      duration: audioFile.duration
+      duration: audioFile.duration,
     });
 
     try {
       const fileUrl = await this.fileService.getFileUrl(audioFile.file_id);
-      const response = await this.messageProcessor.processAudioMessage(fileUrl, userId);
+      const response = await this.messageProcessor.processAudioMessage(fileUrl, userId, context);
       await ctx.reply(response);
+      logger.info('telegram.reply.sent', { replyLength: response.length });
     } catch (error) {
-      logger.error('Error processing audio file', {
-        error: (error as Error).message,
-        userId,
+      logger.error('message.route.failed', {
+        ...serializeError(error),
         fileName
       });
       await ctx.reply('❌ Sorry, I had trouble processing your audio file.');

--- a/src/services/telegram/message-processor.service.ts
+++ b/src/services/telegram/message-processor.service.ts
@@ -1,5 +1,11 @@
 // src/services/telegram/message-processor.service.ts
-import { logger } from '../../utils/logger';
+import {
+  TelemetryContext,
+  extendTelemetryContext,
+  recordMessageProcessingDuration,
+  recordMessageProcessingFailure,
+} from '../../observability';
+import { getLogger, serializeError } from '../../utils/logger';
 import { TextProcessorService } from './processors/text-processor.service';
 import { AudioProcessorService } from './processors/audio-processor.service';
 import { ToolDispatcher } from '../../types/tool.types';
@@ -20,25 +26,73 @@ export class MessageProcessorService {
   /**
    * Processes text messages from users
    */
-  async processTextMessage(text: string, userId?: number): Promise<string> {
-    logger.info('Delegating text message processing', {
-      userId,
+  async processTextMessage(
+    text: string,
+    userId?: number,
+    context?: TelemetryContext,
+  ): Promise<string> {
+    const scopedContext = extendTelemetryContext(context, {
+      component: 'message_processor',
+      userId: userId ? String(userId) : undefined,
+      messageType: 'text',
+      stage: 'route',
+    });
+    const logger = getLogger(scopedContext);
+
+    logger.info('message.route.started', {
       messageLength: text.length,
     });
 
-    return this.textProcessor.processTextMessage(text, userId);
+    const startTime = Date.now();
+    try {
+      const response = await this.textProcessor.processTextMessage(text, userId, scopedContext);
+      recordMessageProcessingDuration('text', Date.now() - startTime);
+      logger.info('message.route.completed', { durationMs: Date.now() - startTime });
+      return response;
+    } catch (error) {
+      recordMessageProcessingFailure('text', 'route');
+      logger.error('message.route.failed', {
+        ...serializeError(error),
+        durationMs: Date.now() - startTime,
+      });
+      throw error;
+    }
   }
 
   /**
    * Processes audio messages (voice notes, audio files)
    */
-  async processAudioMessage(fileUrl: string, userId?: number): Promise<string> {
-    logger.info('Delegating audio message processing', {
-      userId,
-      fileUrl: fileUrl.substring(0, 50) + '...', // Log partial URL for privacy
+  async processAudioMessage(
+    fileUrl: string,
+    userId?: number,
+    context?: TelemetryContext,
+  ): Promise<string> {
+    const scopedContext = extendTelemetryContext(context, {
+      component: 'message_processor',
+      userId: userId ? String(userId) : undefined,
+      messageType: 'audio',
+      stage: 'route',
+    });
+    const logger = getLogger(scopedContext);
+
+    logger.info('message.route.started', {
+      hasFileUrl: !!fileUrl,
     });
 
-    return this.audioProcessor.processAudioMessage(fileUrl, userId);
+    const startTime = Date.now();
+    try {
+      const response = await this.audioProcessor.processAudioMessage(fileUrl, userId, scopedContext);
+      recordMessageProcessingDuration('audio', Date.now() - startTime);
+      logger.info('message.route.completed', { durationMs: Date.now() - startTime });
+      return response;
+    } catch (error) {
+      recordMessageProcessingFailure('audio', 'route');
+      logger.error('message.route.failed', {
+        ...serializeError(error),
+        durationMs: Date.now() - startTime,
+      });
+      throw error;
+    }
   }
 
   /**
@@ -49,14 +103,41 @@ export class MessageProcessorService {
     fileName: string,
     mimeType: string,
     userId?: number,
+    context?: TelemetryContext,
   ): Promise<string> {
-    logger.info('Delegating audio document processing', {
-      userId,
+    const scopedContext = extendTelemetryContext(context, {
+      component: 'message_processor',
+      userId: userId ? String(userId) : undefined,
+      messageType: 'audio_document',
+      stage: 'route',
+    });
+    const logger = getLogger(scopedContext);
+
+    logger.info('message.route.started', {
       fileName,
       mimeType,
     });
 
-    return this.audioProcessor.processAudioDocument(fileUrl, fileName, mimeType, userId);
+    const startTime = Date.now();
+    try {
+      const response = await this.audioProcessor.processAudioDocument(
+        fileUrl,
+        fileName,
+        mimeType,
+        userId,
+        scopedContext,
+      );
+      recordMessageProcessingDuration('audio_document', Date.now() - startTime);
+      logger.info('message.route.completed', { durationMs: Date.now() - startTime });
+      return response;
+    } catch (error) {
+      recordMessageProcessingFailure('audio_document', 'route');
+      logger.error('message.route.failed', {
+        ...serializeError(error),
+        durationMs: Date.now() - startTime,
+      });
+      throw error;
+    }
   }
 
   /**
@@ -72,10 +153,15 @@ export class MessageProcessorService {
     },
     userId?: number,
   ): Promise<string> {
-    logger.info('Processing message with automatic routing', {
-      userId,
+    const scopedContext = extendTelemetryContext(undefined, {
+      component: 'message_processor',
+      userId: userId ? String(userId) : undefined,
       messageType: messageData.type,
+      stage: 'route',
     });
+    const logger = getLogger(scopedContext);
+
+    logger.info('message.route.started', { messageType: messageData.type });
 
     switch (messageData.type) {
       case 'text':
@@ -96,10 +182,7 @@ export class MessageProcessorService {
         );
 
       default:
-        logger.warn('Unknown message type received', {
-          userId,
-          messageType: messageData.type,
-        });
+        logger.warn('message.route.failed', { messageType: messageData.type });
         return (
           `🤖 I received a message, but I'm not sure how to process this type of content.\n` +
           `📝 Supported types: text messages, voice notes, and audio files.\n` +

--- a/src/services/telegram/processors/audio-processor.service.ts
+++ b/src/services/telegram/processors/audio-processor.service.ts
@@ -1,5 +1,10 @@
 // src/services/telegram/processors/audio-processor.service.ts
-import { logger } from '../../../utils/logger';
+import {
+  TelemetryContext,
+  extendTelemetryContext,
+  recordMessageProcessingFailure,
+} from '../../../observability';
+import { getLogger, serializeError } from '../../../utils/logger';
 import { WhisperService } from '../../ai/whisper.service';
 import { GPTService } from '../../ai/gpt.service';
 
@@ -24,15 +29,30 @@ export class AudioProcessorService {
   /**
    * Processes audio messages (voice notes, audio files)
    */
-  async processAudioMessage(fileUrl: string, userId?: number): Promise<string> {
-    logger.info('Processing audio message', {
-      userId,
-      fileUrl: fileUrl.substring(0, 50) + '...', // Log partial URL for privacy
+  async processAudioMessage(
+    fileUrl: string,
+    userId?: number,
+    context?: TelemetryContext,
+  ): Promise<string> {
+    const scopedContext = extendTelemetryContext(context, {
+      component: 'audio_processor',
+      userId: userId ? String(userId) : undefined,
+      messageType: 'audio',
+      stage: 'process',
+    });
+    const logger = getLogger(scopedContext);
+
+    logger.info('message.route.started', {
+      hasFileUrl: !!fileUrl,
     });
 
     try {
       // Transcribe the audio using Whisper service
-      const transcriptionResult = await this.whisperService.transcribeAudio(fileUrl, userId);
+      const transcriptionResult = await this.whisperService.transcribeAudio(
+        fileUrl,
+        userId,
+        scopedContext,
+      );
 
       const { text, processingTimeMs } = transcriptionResult;
 
@@ -46,7 +66,7 @@ export class AudioProcessorService {
 
       // Process the transcribed text with GPT
       try {
-        const response = await this.gptService.processMessage(text, userId?.toString());
+        const response = await this.gptService.processMessage(text, userId?.toString(), scopedContext);
 
         const finalResponse =
           `📝 What you said: ${text}\n\n` +
@@ -55,11 +75,7 @@ export class AudioProcessorService {
 
         return finalResponse;
       } catch (gptError) {
-        logger.warn('Failed to process transcribed audio with GPT', {
-          userId,
-          transcribedText: text.substring(0, 100),
-          error: (gptError as Error).message,
-        });
+        logger.warn('openai.chat.failed', serializeError(gptError));
 
         // Fallback to just showing transcription if GPT processing fails
         return (
@@ -70,10 +86,8 @@ export class AudioProcessorService {
         );
       }
     } catch (error) {
-      logger.error('Failed to process audio message', {
-        userId,
-        error: (error as Error).message,
-      });
+      recordMessageProcessingFailure('audio', 'audio_processor');
+      logger.error('message.route.failed', serializeError(error));
 
       return this.handleAudioProcessingError(error as Error);
     }
@@ -87,16 +101,28 @@ export class AudioProcessorService {
     fileName: string,
     mimeType: string,
     userId?: number,
+    context?: TelemetryContext,
   ): Promise<string> {
-    logger.info('Processing audio document', {
-      userId,
+    const scopedContext = extendTelemetryContext(context, {
+      component: 'audio_processor',
+      userId: userId ? String(userId) : undefined,
+      messageType: 'audio_document',
+      stage: 'process',
+    });
+    const logger = getLogger(scopedContext);
+
+    logger.info('message.route.started', {
       fileName,
       mimeType,
     });
 
     try {
       // Use the same transcription logic as audio messages
-      const transcriptionResult = await this.whisperService.transcribeAudio(fileUrl, userId);
+      const transcriptionResult = await this.whisperService.transcribeAudio(
+        fileUrl,
+        userId,
+        scopedContext,
+      );
 
       const { text, processingTimeMs, fileSizeBytes } = transcriptionResult;
 
@@ -111,7 +137,7 @@ export class AudioProcessorService {
 
       // Process the transcribed text with GPT
       try {
-        const response = await this.gptService.processMessage(text, userId?.toString());
+        const response = await this.gptService.processMessage(text, userId?.toString(), scopedContext);
 
         const finalResponse =
           `📁 Audio document "${fileName}" processed successfully!\n` +
@@ -122,11 +148,9 @@ export class AudioProcessorService {
 
         return finalResponse;
       } catch (gptError) {
-        logger.warn('Failed to process transcribed audio document with GPT', {
-          userId,
+        logger.warn('openai.chat.failed', {
           fileName,
-          transcribedText: text.substring(0, 100),
-          error: (gptError as Error).message,
+          ...serializeError(gptError),
         });
 
         // Fallback to just showing transcription if GPT processing fails
@@ -139,11 +163,11 @@ export class AudioProcessorService {
         );
       }
     } catch (error) {
-      logger.error('Failed to process audio document', {
-        userId,
+      recordMessageProcessingFailure('audio_document', 'audio_processor');
+      logger.error('message.route.failed', {
         fileName,
         mimeType,
-        error: (error as Error).message,
+        ...serializeError(error),
       });
 
       return this.handleAudioDocumentError(error as Error, fileName, mimeType);

--- a/src/services/telegram/processors/text-processor.service.ts
+++ b/src/services/telegram/processors/text-processor.service.ts
@@ -1,5 +1,11 @@
 // src/services/telegram/processors/text-processor.service.ts
-import { logger } from '../../../utils/logger';
+import {
+  TelemetryContext,
+  extendTelemetryContext,
+  hashContent,
+  recordMessageProcessingFailure,
+} from '../../../observability';
+import { getLogger, serializeError } from '../../../utils/logger';
 import { GPTService } from '../../ai';
 import { ToolDispatcher } from '../../../types/tool.types';
 
@@ -17,28 +23,39 @@ export class TextProcessorService {
   /**
    * Processes text messages from users
    */
-  async processTextMessage(text: string, userId?: number): Promise<string> {
-    logger.info('Processing text message', {
-      userId,
+  async processTextMessage(
+    text: string,
+    userId?: number,
+    context?: TelemetryContext,
+  ): Promise<string> {
+    const scopedContext = extendTelemetryContext(context, {
+      component: 'text_processor',
+      userId: userId ? String(userId) : undefined,
+      messageType: 'text',
+      stage: 'process',
+    });
+    const logger = getLogger(scopedContext);
+
+    logger.info('message.route.started', {
       messageLength: text.length,
+      messageHash: hashContent(text),
     });
 
     try {
       // Process the message using GPT
-      const response = await this.gptService.processMessage(text, userId?.toString());
+      const response = await this.gptService.processMessage(text, userId?.toString(), scopedContext);
 
-      logger.info('Text message processed successfully', {
-        userId,
+      logger.info('message.route.completed', {
         messageLength: text.length,
         responseLength: response.length,
       });
 
       return response;
     } catch (error) {
-      logger.error('Failed to process text message', {
-        userId,
+      recordMessageProcessingFailure('text', 'text_processor');
+      logger.error('message.route.failed', {
         messageLength: text.length,
-        error: (error as Error).message,
+        ...serializeError(error),
       });
 
       return this.handleTextProcessingError(error as Error, text);
@@ -69,7 +86,7 @@ export class TextProcessorService {
     // Fallback response for other errors
     return (
       `I encountered an issue processing your request.\n` +
-      `💭 Your message: "${text.length > 100 ? text.substring(0, 100) + '...' : text}"\n\n` +
+      `💭 Message length: ${text.length} characters\n\n` +
       `🔄 Please try again, and I'll do my best to help!`
     );
   }

--- a/src/services/telegram/telegram-bot.service.ts
+++ b/src/services/telegram/telegram-bot.service.ts
@@ -10,6 +10,14 @@ import { BotActivityService } from './bot-activity.service';
 import { BotStatusService } from './bot-status.service';
 import { TodoistAPIService } from '../external/todoist-api.service';
 import { GPT_CONSTANTS } from '../ai/constants/gpt.constants';
+import {
+  extendTelemetryContext,
+  getTelemetryContext,
+  recordTelegramUpdate,
+  runWithTelemetryContext,
+  TelemetryContext,
+} from '../../observability';
+import { getLogger, serializeError } from '../../utils/logger';
 
 /**
  * Service class responsible for managing Telegram bot operations
@@ -48,7 +56,7 @@ export class TelegramBotService {
     this.setupBotHandlers();
     this.setupErrorHandling();
 
-    logger.info('Telegram bot initialized successfully');
+    logger.info('telegram.bot.initialized');
   }
 
   /**
@@ -64,19 +72,25 @@ export class TelegramBotService {
   private setupErrorHandling(): void {
     this.bot.catch(async (err: unknown, ctx: Context) => {
       const error = err as Error;
-      logger.error('Bot error occurred', {
-        error: error.message,
-        stack: error.stack,
-        userId: ctx.from?.id,
-        chatId: ctx.chat?.id
+      const context = extendTelemetryContext(this.getContextFromTelegram(ctx), {
+        component: 'telegram_bot',
+        stage: 'bot_error',
+      });
+      const scopedLogger = getLogger(context);
+
+      scopedLogger.error('telegram.update.failed', {
+        ...serializeError(error),
       });
 
       try {
         await ctx.reply('❌ Sorry, something went wrong. Please try again.');
+        scopedLogger.info('telegram.reply.sent', {
+          replyLength: 47,
+        });
       } catch (replyError) {
-        logger.error('Failed to send error message', {
-          originalError: error.message,
-          replyError: (replyError as Error).message
+        scopedLogger.error('telegram.reply.failed', {
+          ...serializeError(replyError),
+          originalErrorMessage: error.message,
         });
       }
     });
@@ -89,7 +103,7 @@ export class TelegramBotService {
     try {
       const fullWebhookUrl = `${webhookUrl}/webhook/${secretToken}`;
 
-      logger.info('Setting up webhook', { url: fullWebhookUrl });
+      logger.info('telegram.webhook.setup_requested', { webhookUrl });
 
       await this.syncCommands();
 
@@ -99,11 +113,11 @@ export class TelegramBotService {
         drop_pending_updates: true
       });
 
-      logger.info('Webhook configured successfully');
+      logger.info('telegram.webhook.configured');
     } catch (error) {
-      logger.error('Failed to set webhook', {
-        error: (error as Error).message,
-        webhookUrl
+      logger.error('telegram.webhook.failed', {
+        ...serializeError(error),
+        webhookUrl,
       });
       throw new Error(`Webhook setup failed: ${(error as Error).message}`);
     }
@@ -115,11 +129,9 @@ export class TelegramBotService {
   async removeWebhook(): Promise<void> {
     try {
       await this.bot.telegram.deleteWebhook({ drop_pending_updates: true });
-      logger.info('Webhook removed successfully');
+      logger.info('telegram.webhook.removed');
     } catch (error) {
-      logger.error('Failed to remove webhook', {
-        error: (error as Error).message
-      });
+      logger.error('telegram.webhook.remove_failed', serializeError(error));
       throw error;
     }
   }
@@ -127,13 +139,25 @@ export class TelegramBotService {
   /**
    * Handles incoming updates from Telegram webhook
    */
-  async handleUpdate(update: any): Promise<void> {
+  async handleUpdate(update: any, context: TelemetryContext): Promise<void> {
+    const enrichedContext = extendTelemetryContext(context, {
+      component: 'telegram_update',
+      chatId: update?.message?.chat?.id || update?.callback_query?.message?.chat?.id,
+      userId: update?.message?.from?.id ? String(update.message.from.id) : undefined,
+      stage: 'update',
+    });
+    const scopedLogger = getLogger(enrichedContext);
+
     try {
-      await this.bot.handleUpdate(update);
+      scopedLogger.info('telegram.update.received', {
+        updateType: this.getUpdateType(update),
+      });
+      recordTelegramUpdate(this.getUpdateType(update));
+
+      await runWithTelemetryContext(enrichedContext, () => this.bot.handleUpdate(update));
     } catch (error) {
-      logger.error('Error handling Telegram update', {
-        updateId: update.update_id,
-        error: (error as Error).message
+      scopedLogger.error('telegram.update.failed', {
+        ...serializeError(error),
       });
       throw error;
     }
@@ -147,13 +171,21 @@ export class TelegramBotService {
     text: string,
     options?: any
   ): Promise<Message.TextMessage> {
+    const scopedLogger = getLogger(
+      this.getContextFromOptions(options, { component: 'telegram_send_message', chatId }),
+    );
     try {
-      return await this.bot.telegram.sendMessage(chatId, text, options);
-    } catch (error) {
-      logger.error('Failed to send message', {
+      const sentMessage = await this.bot.telegram.sendMessage(chatId, text, options);
+      scopedLogger.info('telegram.reply.sent', {
         chatId,
         textLength: text.length,
-        error: (error as Error).message
+      });
+      return sentMessage;
+    } catch (error) {
+      scopedLogger.error('telegram.reply.failed', {
+        chatId,
+        textLength: text.length,
+        ...serializeError(error),
       });
       throw error;
     }
@@ -165,12 +197,10 @@ export class TelegramBotService {
   async getBotInfo(): Promise<any> {
     try {
       const botInfo = await this.bot.telegram.getMe();
-      logger.debug('Retrieved bot info', { username: botInfo.username });
+      logger.debug('telegram.bot.info_retrieved', { username: botInfo.username });
       return botInfo;
     } catch (error) {
-      logger.error('Failed to get bot info', {
-        error: (error as Error).message
-      });
+      logger.error('telegram.bot.info_failed', serializeError(error));
       throw error;
     }
   }
@@ -182,11 +212,9 @@ export class TelegramBotService {
     try {
       await this.syncCommands();
       await this.bot.launch();
-      logger.info('Bot started polling for updates');
+      logger.info('telegram.bot.polling_started');
     } catch (error) {
-      logger.error('Failed to start polling', {
-        error: (error as Error).message
-      });
+      logger.error('telegram.bot.polling_failed', serializeError(error));
       throw error;
     }
   }
@@ -197,11 +225,9 @@ export class TelegramBotService {
   async stop(): Promise<void> {
     try {
       this.bot.stop();
-      logger.info('Bot stopped successfully');
+      logger.info('telegram.bot.stopped');
     } catch (error) {
-      logger.error('Error stopping bot', {
-        error: (error as Error).message
-      });
+      logger.error('telegram.bot.stop_failed', serializeError(error));
     }
   }
 
@@ -210,5 +236,37 @@ export class TelegramBotService {
       { command: 'help', description: 'Show available commands and supported inputs' },
       { command: 'status', description: 'Show bot health, uptime, and dependency status' },
     ]);
+  }
+
+  private getUpdateType(update: any): string {
+    if (update?.message?.voice) return 'voice';
+    if (update?.message?.audio) return 'audio';
+    if (update?.message?.document) return 'document';
+    if (update?.message?.text) return 'text';
+    return 'unknown';
+  }
+
+  private getContextFromTelegram(ctx: Context): TelemetryContext | undefined {
+    const currentContext = getTelemetryContext();
+    if (!currentContext) {
+      return undefined;
+    }
+
+    return extendTelemetryContext(currentContext, {
+      updateId: (ctx.update as any)?.update_id,
+      chatId: ctx.chat?.id,
+      userId: ctx.from?.id ? String(ctx.from.id) : undefined,
+    });
+  }
+
+  private getContextFromOptions(
+    options: any,
+    fallback: Partial<TelemetryContext>,
+  ): TelemetryContext | undefined {
+    if (options?.telemetryContext) {
+      return extendTelemetryContext(options.telemetryContext, fallback);
+    }
+    const currentContext = getTelemetryContext();
+    return currentContext ? extendTelemetryContext(currentContext, fallback) : undefined;
   }
 }

--- a/src/services/tools/direct-tool-dispatcher.service.ts
+++ b/src/services/tools/direct-tool-dispatcher.service.ts
@@ -3,8 +3,8 @@
  *
  * @module DirectToolCallDispatcher
  */
-
-import { logger } from '../../utils/logger';
+import { TelemetryContext, extendTelemetryContext, recordToolCall } from '../../observability';
+import { getLogger, serializeError } from '../../utils/logger';
 import { ToolCall, ToolResult, ToolDispatcher } from '../../types/tool.types';
 import { TodoistAPIService } from '../external/todoist-api.service';
 
@@ -22,7 +22,7 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
 
     this.todoistService = new TodoistAPIService(todoistApiKey);
 
-    logger.info('DirectToolCallDispatcher initialized', {
+    getLogger({ requestId: 'startup', component: 'tool_dispatcher' }).info('tool.dispatcher.initialized', {
       hasTodoistService: !!this.todoistService,
     });
   }
@@ -34,15 +34,24 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
    * @param userId - User ID for context/authorization
    * @returns Promise<ToolResult[]> - Results of all tool executions
    */
-  async executeToolCalls(toolCalls: ToolCall[], userId: string): Promise<ToolResult[]> {
-    logger.info('Executing tool calls directly', {
-      userId,
+  async executeToolCalls(
+    toolCalls: ToolCall[],
+    userId: string,
+    context?: TelemetryContext,
+  ): Promise<ToolResult[]> {
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        component: 'tool_dispatcher',
+        userId,
+      }),
+    );
+    logger.info('tool.dispatch.started', {
       toolCallsCount: toolCalls.length,
       functionNames: toolCalls.map((tc) => tc.function.name),
     });
 
     // Execute all tool calls in parallel for better performance
-    const promises = toolCalls.map((toolCall) => this.executeToolCall(toolCall, userId));
+    const promises = toolCalls.map((toolCall) => this.executeToolCall(toolCall, userId, context));
     const results = await Promise.allSettled(promises);
 
     // Convert Promise.allSettled results to our ToolResult format
@@ -72,13 +81,24 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
    * @returns Promise<any> - The result of the function execution
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async executeToolCall(toolCall: ToolCall, userId: string): Promise<any> {
+  private async executeToolCall(
+    toolCall: ToolCall,
+    userId: string,
+    context?: TelemetryContext,
+  ): Promise<any> {
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        component: 'tool_dispatcher',
+        userId,
+        stage: 'tool_call',
+      }),
+    );
+    const startTime = Date.now();
     try {
       const functionName = toolCall.function.name;
       const parameters = JSON.parse(toolCall.function.arguments);
 
-      logger.debug('Executing tool call', {
-        userId,
+      logger.info('tool.call.started', {
         functionName,
         toolCallId: toolCall.id,
         parameters: Object.keys(parameters),
@@ -86,21 +106,21 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
 
       const result = await this.routeFunctionCall(functionName, parameters);
 
-      logger.debug('Tool call executed successfully', {
-        userId,
+      logger.info('tool.call.succeeded', {
         functionName,
         toolCallId: toolCall.id,
         hasResult: !!result,
       });
+      recordToolCall(functionName, 'success', Date.now() - startTime);
 
       return result;
     } catch (error) {
-      logger.error('Tool call execution error', {
-        userId,
+      logger.error('tool.call.failed', {
         functionName: toolCall.function.name,
         toolCallId: toolCall.id,
-        error: (error as Error).message,
+        ...serializeError(error),
       });
+      recordToolCall(toolCall.function.name, 'error', Date.now() - startTime);
       throw error;
     }
   }

--- a/src/types/gpt.types.ts
+++ b/src/types/gpt.types.ts
@@ -34,6 +34,12 @@ export interface MessageProcessingResult {
   functionCallsCount: number;
   /** Model used for generation */
   model: string;
+  /** Usage metrics returned by OpenAI when available */
+  usage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
 }
 
 /**

--- a/src/types/tool.types.ts
+++ b/src/types/tool.types.ts
@@ -1,3 +1,5 @@
+import { TelemetryContext } from '../observability';
+
 // Interface for OpenAI function calls
 export interface ToolCall {
   id: string;
@@ -18,6 +20,10 @@ export interface ToolResult {
 
 // Common interface for tool dispatchers
 export interface ToolDispatcher {
-  executeToolCalls(toolCalls: ToolCall[], userId: string): Promise<ToolResult[]>;
+  executeToolCalls(
+    toolCalls: ToolCall[],
+    userId: string,
+    context?: TelemetryContext,
+  ): Promise<ToolResult[]>;
   isFunctionSupported(functionName: string): boolean;
 }

--- a/src/utils/ai/audioConverter.ts
+++ b/src/utils/ai/audioConverter.ts
@@ -5,7 +5,8 @@ import { spawn } from 'child_process';
 import { writeFile, unlink } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { logger } from '../logger';
+import { TelemetryContext, extendTelemetryContext } from '../../observability';
+import { createComponentLogger, serializeError } from '../logger';
 
 /**
  * Supported input audio formats that can be converted
@@ -93,11 +94,18 @@ export class AudioConverter {
     audioBuffer: Buffer,
     originalExtension: string,
     userId?: number,
+    context?: TelemetryContext,
   ): Promise<ConversionResult> {
     const startTime = Date.now();
+    const logger = createComponentLogger(
+      'audio_converter',
+      extendTelemetryContext(context, {
+        userId: userId ? String(userId) : undefined,
+        stage: 'conversion',
+      }),
+    );
 
-    logger.info('Starting audio conversion', {
-      userId,
+    logger.info('audio.conversion.started', {
       originalFormat: originalExtension,
       targetFormat: TARGET_FORMAT,
       originalSizeBytes: audioBuffer.length,
@@ -126,8 +134,7 @@ export class AudioConverter {
         convertedSizeBytes: convertedBuffer.length,
       };
 
-      logger.info('Audio conversion completed successfully', {
-        userId,
+      logger.info('audio.conversion.succeeded', {
         originalFormat: originalExtension,
         targetFormat: TARGET_FORMAT,
         conversionTimeMs,
@@ -140,12 +147,11 @@ export class AudioConverter {
     } catch (error) {
       const conversionTimeMs = Date.now() - startTime;
 
-      logger.error('Audio conversion failed', {
-        userId,
+      logger.error('audio.conversion.failed', {
         originalFormat: originalExtension,
         targetFormat: TARGET_FORMAT,
-        error: (error as Error).message,
         conversionTimeMs,
+        ...serializeError(error),
       });
 
       // Provide a more helpful error if the installer package is missing.
@@ -275,14 +281,15 @@ export class AudioConverter {
    * @private
    */
   private static async cleanupTempFiles(filePaths: string[]): Promise<void> {
+    const logger = createComponentLogger('audio_converter');
     const cleanupPromises = filePaths.map(async (filePath) => {
       try {
         await unlink(filePath);
       } catch (error) {
         // Ignore cleanup errors, just log them
-        logger.warn('Failed to cleanup temporary file', {
+        logger.warn('audio.conversion.cleanup_failed', {
           filePath,
-          error: (error as Error).message,
+          ...serializeError(error),
         });
       }
     });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,12 +1,115 @@
-// services/utils/logger.ts
 import winston from 'winston';
+import { TelemetryContext, LogFields } from '../observability/types';
 
-export const logger = winston.createLogger({
-  level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+const REDACTED = '[REDACTED]';
+const TELEGRAM_FILE_URL_PATTERN = /https:\/\/api\.telegram\.org\/file\/bot[^\s"]+/g;
+const ENV_SECRET_KEYS = ['BOT_TOKEN', 'TELEGRAM_SECRET_TOKEN', 'OPENAI_API_KEY', 'TODOIST_API_KEY'];
+
+function getLogLevel(): string {
+  if (process.env.LOG_LEVEL) {
+    return process.env.LOG_LEVEL;
+  }
+
+  return process.env.NODE_ENV === 'production' ? 'info' : 'debug';
+}
+
+function sanitizeString(value: string): string {
+  let sanitized = value.replace(TELEGRAM_FILE_URL_PATTERN, REDACTED);
+
+  for (const envKey of ENV_SECRET_KEYS) {
+    const secret = process.env[envKey];
+    if (secret) {
+      sanitized = sanitized.split(secret).join(REDACTED);
+    }
+  }
+
+  return sanitized;
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (value instanceof Error) {
+    return serializeError(value);
+  }
+
+  if (typeof value === 'string') {
+    return sanitizeString(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => [
+        key,
+        sanitizeValue(nestedValue),
+      ]),
+    );
+  }
+
+  return value;
+}
+
+const sanitizeFormat = winston.format((info) => sanitizeValue(info) as winston.Logform.TransformableInfo);
+
+const baseLogger = winston.createLogger({
+  level: getLogLevel(),
+  defaultMeta: {
+    service: process.env.SERVICE_NAME || 'jarvis-mcp',
+    env: process.env.NODE_ENV || 'development',
+    version: process.env.SERVICE_VERSION || process.env.npm_package_version || 'unknown',
+  },
   format: winston.format.combine(
     winston.format.timestamp(),
-    winston.format.errors({ stack: true }), // logs stack trace
+    winston.format.errors({ stack: true }),
+    sanitizeFormat(),
     winston.format.json(),
   ),
   transports: [new winston.transports.Console()],
 });
+
+export const logger = baseLogger;
+
+export function serializeError(error: unknown): LogFields {
+  if (!(error instanceof Error)) {
+    return {
+      errorMessage: typeof error === 'string' ? sanitizeString(error) : 'Unknown error',
+    };
+  }
+
+  const normalized = error as Error & { code?: string };
+  return {
+    errorName: normalized.name,
+    errorMessage: sanitizeString(normalized.message),
+    errorStack: normalized.stack ? sanitizeString(normalized.stack) : undefined,
+    errorCode: normalized.code,
+  };
+}
+
+export function getLogger(context?: TelemetryContext): winston.Logger {
+  if (!context) {
+    return baseLogger;
+  }
+
+  return baseLogger.child(
+    Object.fromEntries(
+      Object.entries(context).filter(([, value]) => value !== undefined),
+    ) as TelemetryContext,
+  );
+}
+
+export function createComponentLogger(
+  component: string,
+  context?: TelemetryContext,
+): winston.Logger {
+  if (!context) {
+    return baseLogger.child({ component });
+  }
+
+  return getLogger(context).child({ component });
+}
+
+export function sanitizeForLogging(value: unknown): unknown {
+  return sanitizeValue(value);
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,8 +1,27 @@
+type MockLogger = {
+  info: jest.Mock;
+  warn: jest.Mock;
+  error: jest.Mock;
+  debug: jest.Mock;
+  child: jest.Mock;
+};
+
+const mockedLogger: MockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn(),
+};
+
+mockedLogger.child.mockImplementation(() => mockedLogger);
+
 jest.mock('../src/utils/logger', () => ({
-  logger: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    debug: jest.fn(),
-  },
+  logger: mockedLogger,
+  getLogger: jest.fn(() => mockedLogger),
+  createComponentLogger: jest.fn(() => mockedLogger),
+  serializeError: jest.fn((error: unknown) => ({
+    errorMessage: error instanceof Error ? error.message : String(error),
+  })),
+  sanitizeForLogging: jest.fn((value: unknown) => value),
 }));

--- a/tests/unit/controllers/webhook.controller.test.ts
+++ b/tests/unit/controllers/webhook.controller.test.ts
@@ -66,7 +66,13 @@ describe('createWebhookRouter', () => {
     );
 
     expect(response.sendStatus).toHaveBeenCalledWith(200);
-    expect(handleUpdate).toHaveBeenCalledWith(update);
+    expect(handleUpdate).toHaveBeenCalledWith(
+      update,
+      expect.objectContaining({
+        component: 'webhook',
+        updateId: 42,
+      }),
+    );
   });
 
   it('returns 500 when bot update handling fails', async () => {

--- a/tests/unit/observability/logger.test.ts
+++ b/tests/unit/observability/logger.test.ts
@@ -1,0 +1,30 @@
+describe('logger utilities', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('redacts secrets and telegram file urls from log payloads', () => {
+    process.env.OPENAI_API_KEY = 'openai-secret';
+    process.env.BOT_TOKEN = 'bot-secret';
+
+    const { sanitizeForLogging, serializeError } = jest.requireActual('../../../src/utils/logger');
+
+    expect(
+      sanitizeForLogging({
+        apiKey: 'openai-secret',
+        fileUrl: 'https://api.telegram.org/file/botbot-secret/private/file.ogg',
+      }),
+    ).toEqual({
+      apiKey: '[REDACTED]',
+      fileUrl: '[REDACTED]',
+    });
+
+    expect(serializeError(new Error('boom openai-secret'))).toEqual(
+      expect.objectContaining({
+        errorMessage: 'boom [REDACTED]',
+      }),
+    );
+  });
+});

--- a/tests/unit/observability/metrics.test.ts
+++ b/tests/unit/observability/metrics.test.ts
@@ -1,0 +1,32 @@
+import {
+  getMetricsContentType,
+  getMetricsSnapshot,
+  recordOpenAIRequest,
+  recordWebhook,
+  resetMetrics,
+} from '../../../src/observability';
+
+describe('observability metrics', () => {
+  beforeEach(() => {
+    resetMetrics();
+  });
+
+  it('renders prometheus metrics text for recorded counters and histograms', async () => {
+    recordWebhook('success', 42);
+    recordOpenAIRequest(
+      { model: 'gpt-4o', operation: 'simple_text', status: 'success' },
+      120,
+      { promptTokens: 10, completionTokens: 4, totalTokens: 14 },
+    );
+
+    const output = await getMetricsSnapshot();
+
+    expect(getMetricsContentType()).toContain('text/plain');
+    expect(output).toContain('jarvis_webhook_requests_total{status="success"} 1');
+    expect(output).toContain(
+      'jarvis_openai_requests_total{model="gpt-4o",operation="simple_text",status="success"} 1',
+    );
+    expect(output).toContain('jarvis_openai_tokens_total{direction="total",model="gpt-4o"} 14');
+    expect(output).toContain('jarvis_webhook_duration_ms_bucket');
+  });
+});

--- a/tests/unit/services/telegram/handlers/message-handlers.test.ts
+++ b/tests/unit/services/telegram/handlers/message-handlers.test.ts
@@ -40,6 +40,11 @@ describe('MessageHandlers', () => {
       'meeting.mp3',
       'audio/mpeg',
       123,
+      expect.objectContaining({
+        component: 'telegram_message',
+        messageType: 'audio_document',
+        userId: '123',
+      }),
     );
     expect(messageProcessor.processAudioMessage).not.toHaveBeenCalled();
     expect(activityService.recordActivity).toHaveBeenCalledWith('message_document');


### PR DESCRIPTION
## Summary
Add a structured observability foundation for Telegram request handling, OpenAI/Whisper execution, and tool dispatch.

## Why
Async-safe tracing and metrics were missing, which made it hard to debug request flow, measure latency, and track token usage or failure rates.

## Changes made
- add a shared observability layer for telemetry context propagation, log redaction, metrics export, and OpenAI cost estimation
- thread request-scoped context through webhook ingress, Telegram handlers, message processors, GPT, Whisper, audio conversion, tool dispatch, and Todoist API calls
- expose `/metrics`, add lifecycle and fatal runtime events, and document the local monitoring surface
- add unit coverage for metrics export, logger redaction, and updated telemetry-aware handler behavior

## Testing
- `npm run build`
- `npm test -- --runInBand`

## Notes
- `git push` did not complete from this environment, so the remote branch was created through the GitHub API using the committed tree from this workspace
- metrics are exported in Prometheus text format via an in-repo exporter rather than `prom-client`, because package installation stalled in this environment
