### PR TITLE
[Feature] add async job queue execution for Telegram requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "express": "^5.1.0",
         "fluent-ffmpeg": "^2.1.3",
         "openai": "^5.0.2",
+        "sqlite": "^5.1.1",
+        "sqlite3": "^6.0.1",
         "telegraf": "^4.16.3",
         "todoist-mcp": "^1.2.3",
         "winston": "^3.17.0"
@@ -1177,6 +1179,15 @@
         "win32"
       ]
     },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1241,6 +1252,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2224,6 +2246,52 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@npmcli/agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "optional": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -2859,6 +2927,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2918,6 +2995,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -3254,7 +3340,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3284,11 +3369,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -3400,7 +3492,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3457,6 +3548,89 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+      "optional": true,
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cacache/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "optional": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cacache/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "optional": true,
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "optional": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/cachedir": {
@@ -3592,6 +3766,14 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
@@ -4282,12 +4464,34 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4354,6 +4558,14 @@
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "engines": {
         "node": ">=8"
       }
@@ -4502,11 +4714,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5142,6 +5362,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -5171,6 +5399,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "optional": true
     },
     "node_modules/express": {
       "version": "5.1.0",
@@ -5388,6 +5622,11 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -5637,6 +5876,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -5651,6 +5895,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -5795,6 +6051,11 @@
         "node": ">=16"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5927,7 +6188,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -6007,6 +6268,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "optional": true
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6021,6 +6288,32 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -6049,7 +6342,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6280,6 +6572,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -9186,6 +9487,29 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/make-fetch-happen": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
+      "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+      "optional": true,
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -9344,6 +9668,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -9361,11 +9696,151 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "optional": true
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "optional": true
+    },
+    "node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -9402,6 +9877,11 @@
         "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -9416,6 +9896,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-fetch": {
@@ -9436,6 +9935,54 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
+      "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^15.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/node-int64": {
@@ -9479,6 +10026,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/normalize-path": {
@@ -9752,6 +10314,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-timeout": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
@@ -9857,6 +10431,31 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "optional": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "optional": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
@@ -9998,6 +10597,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10065,6 +10690,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "optional": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -10098,6 +10732,15 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -10183,6 +10826,33 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -10456,7 +11126,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10608,6 +11277,49 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -10670,6 +11382,44 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10707,6 +11457,49 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sqlite": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sqlite/-/sqlite-5.1.1.tgz",
+      "integrity": "sha512-oBkezXa2hnkfuJwUo44Hl9hS3er+YFtueifoajrgidvqsJRQFpc5fKoAkAor1O5ZnLoa28GBScfHXs8j0K358Q=="
+    },
+    "node_modules/sqlite3": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-6.0.1.tgz",
+      "integrity": "sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^8.0.0",
+        "prebuild-install": "^7.1.3",
+        "tar": "^7.5.10"
+      },
+      "engines": {
+        "node": ">=20.17.0"
+      },
+      "optionalDependencies": {
+        "node-gyp": "12.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "12.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ssri": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -10930,6 +11723,60 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/telegraf": {
       "version": "4.16.3",
       "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
@@ -10999,6 +11846,51 @@
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "optional": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -11210,6 +12102,17 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "express": "^5.1.0",
     "fluent-ffmpeg": "^2.1.3",
     "openai": "^5.0.2",
+    "sqlite": "^5.1.1",
+    "sqlite3": "^6.0.1",
     "telegraf": "^4.16.3",
     "todoist-mcp": "^1.2.3",
     "winston": "^3.17.0"

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,41 +1,94 @@
-// src/app.ts — service wiring
 import 'dotenv/config';
 import { logger } from './utils/logger';
 import { TelegramBotService } from './services/telegram/telegram-bot.service';
 import { MessageProcessorService } from './services/telegram/message-processor.service';
 import { TelegramConfig } from './types/telegram.types';
 import { DirectToolCallDispatcher } from './services/tools/direct-tool-dispatcher.service';
+import { SQLiteService } from './services/persistence/sqlite.service';
+import { MessageRepository } from './repositories/message.repository';
+import { JobRepository } from './repositories/job.repository';
+import { JobEventRepository } from './repositories/job-event.repository';
+import { JobService } from './services/jobs/job.service';
+import { TelegramUpdateIntakeService } from './services/telegram/telegram-update-intake.service';
+import { JobSchedulerService } from './services/jobs/job-scheduler.service';
+import { JobQueueService } from './services/jobs/job-queue.service';
+import { TelegramResponseService } from './services/telegram/telegram-response.service';
+import { TelegramProgressService } from './services/telegram/telegram-progress.service';
+import { JobProgressService } from './services/jobs/job-progress.service';
+import { JobWorkerService } from './services/jobs/job-worker.service';
+import { TextJobProcessor } from './services/jobs/processors/text-job.processor';
+import { AudioJobProcessor } from './services/jobs/processors/audio-job.processor';
+import { FileService } from './services/telegram/file.service';
 
-// Validate required environment variables before constructing any service
-const REQUIRED_ENV_VARS = [
-  'BOT_TOKEN',
-  'NGROK_URL',
-  'TELEGRAM_SECRET_TOKEN',
-  'OPENAI_API_KEY',
-  'TODOIST_API_KEY',
-];
+const REQUIRED_ENV_VARS = ['BOT_TOKEN', 'NGROK_URL', 'TELEGRAM_SECRET_TOKEN', 'OPENAI_API_KEY'];
 
-for (const key of REQUIRED_ENV_VARS) {
-  if (!process.env[key]) {
-    console.error(`[startup] Missing required environment variable: ${key}`);
-    process.exit(1);
-  }
+export interface ApplicationServices {
+  botService: TelegramBotService;
+  workerService: JobWorkerService;
+  sqliteService: SQLiteService;
 }
 
-const BOT_TOKEN = process.env.BOT_TOKEN!;
-const NGROK_URL = process.env.NGROK_URL!;
-const TELEGRAM_SECRET_TOKEN = process.env.TELEGRAM_SECRET_TOKEN!;
+export async function initializeApplication(): Promise<ApplicationServices> {
+  for (const key of REQUIRED_ENV_VARS) {
+    if (!process.env[key]) {
+      console.error(`[startup] Missing required environment variable: ${key}`);
+      process.exit(1);
+    }
+  }
 
-// Wire up services
-const toolDispatcher = new DirectToolCallDispatcher();
-const messageProcessor = new MessageProcessorService(toolDispatcher);
+  const BOT_TOKEN = process.env.BOT_TOKEN!;
+  const NGROK_URL = process.env.NGROK_URL!;
+  const TELEGRAM_SECRET_TOKEN = process.env.TELEGRAM_SECRET_TOKEN!;
 
-const telegramConfig: TelegramConfig = {
-  token: BOT_TOKEN,
-  webhookUrl: NGROK_URL,
-  secretToken: TELEGRAM_SECRET_TOKEN,
-};
+  const sqliteService = new SQLiteService();
+  await sqliteService.initialize();
 
-export const botService = new TelegramBotService(telegramConfig, messageProcessor);
+  const db = sqliteService.getDatabase();
+  const messageRepository = new MessageRepository(db);
+  const jobRepository = new JobRepository(db);
+  const jobEventRepository = new JobEventRepository(db);
 
-logger.info('Services initialised');
+  const jobService = new JobService(messageRepository, jobRepository);
+  const intakeService = new TelegramUpdateIntakeService(jobService);
+  const toolDispatcher = process.env.TODOIST_API_KEY ? new DirectToolCallDispatcher() : undefined;
+  const messageProcessor = new MessageProcessorService(toolDispatcher);
+
+  const telegramConfig: TelegramConfig = {
+    token: BOT_TOKEN,
+    webhookUrl: NGROK_URL,
+    secretToken: TELEGRAM_SECRET_TOKEN,
+  };
+
+  const botService = new TelegramBotService(telegramConfig, intakeService, jobService);
+  const fileService = new FileService(BOT_TOKEN, botService.bot.telegram);
+  const responseService = new TelegramResponseService(botService.bot.telegram);
+  const progressService = new TelegramProgressService(responseService, jobRepository);
+  const jobProgressService = new JobProgressService(
+    jobEventRepository,
+    jobRepository,
+    progressService,
+  );
+  const jobSchedulerService = new JobSchedulerService(jobRepository);
+  const jobQueueService = new JobQueueService(jobRepository, jobSchedulerService);
+  const workerService = new JobWorkerService(
+    jobQueueService,
+    jobProgressService,
+    jobService,
+    responseService,
+  );
+
+  workerService.registerProcessor('text', new TextJobProcessor(messageProcessor));
+  workerService.registerProcessor('voice', new AudioJobProcessor(messageProcessor, fileService));
+  workerService.registerProcessor(
+    'audio_document',
+    new AudioJobProcessor(messageProcessor, fileService),
+  );
+
+  logger.info('Services initialised');
+
+  return {
+    botService,
+    workerService,
+    sqliteService,
+  };
+}

--- a/src/repositories/job-event.repository.ts
+++ b/src/repositories/job-event.repository.ts
@@ -1,0 +1,36 @@
+import { Database } from 'sqlite';
+import sqlite3 from 'sqlite3';
+import { JobEventRecord } from '../types/job.types';
+
+export class JobEventRepository {
+  constructor(private readonly db: Database<sqlite3.Database, sqlite3.Statement>) {}
+
+  async create(
+    jobId: string,
+    eventType: string,
+    message?: string,
+    payload?: Record<string, unknown>,
+  ): Promise<JobEventRecord> {
+    const createdAt = new Date().toISOString();
+    const result = await this.db.run(
+      `
+        INSERT INTO job_events (job_id, event_type, message, payload_json, created_at)
+        VALUES (?, ?, ?, ?, ?)
+      `,
+      jobId,
+      eventType,
+      message || null,
+      payload ? JSON.stringify(payload) : null,
+      createdAt,
+    );
+
+    return {
+      id: result.lastID!,
+      jobId,
+      eventType,
+      message: message || null,
+      payloadJson: payload ? JSON.stringify(payload) : null,
+      createdAt,
+    };
+  }
+}

--- a/src/repositories/job.repository.ts
+++ b/src/repositories/job.repository.ts
@@ -1,0 +1,335 @@
+import { randomUUID } from 'crypto';
+import { Database } from 'sqlite';
+import sqlite3 from 'sqlite3';
+import { JobPayload, JobRecord, JobStatus, JobType } from '../types/job.types';
+
+interface CreateJobParams {
+  userId: number;
+  chatId: number;
+  messageId: number;
+  type: JobType;
+  priority?: number;
+  concurrencyKey?: string | null;
+  dedupeKey: string;
+  payload: JobPayload;
+  maxAttempts?: number;
+}
+
+export class JobRepository {
+  constructor(private readonly db: Database<sqlite3.Database, sqlite3.Statement>) {}
+
+  async create(params: CreateJobParams): Promise<JobRecord> {
+    const now = new Date().toISOString();
+    const id = randomUUID();
+    const record: JobRecord = {
+      id,
+      userId: params.userId,
+      chatId: params.chatId,
+      messageId: params.messageId,
+      type: params.type,
+      status: 'queued',
+      priority: params.priority ?? 100,
+      concurrencyKey: params.concurrencyKey ?? null,
+      dedupeKey: params.dedupeKey,
+      payloadJson: JSON.stringify(params.payload),
+      resultJson: null,
+      errorJson: null,
+      attempts: 0,
+      maxAttempts: params.maxAttempts ?? 2,
+      lockedAt: null,
+      workerId: null,
+      startedAt: null,
+      completedAt: null,
+      supersededByJobId: null,
+      ackMessageId: null,
+      progressMessageId: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.db.run(
+      `
+        INSERT INTO jobs (
+          id, user_id, chat_id, message_id, type, status, priority,
+          concurrency_key, dedupe_key, payload_json, result_json, error_json,
+          attempts, max_attempts, locked_at, worker_id, started_at, completed_at,
+          superseded_by_job_id, ack_message_id, progress_message_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      record.id,
+      record.userId,
+      record.chatId,
+      record.messageId,
+      record.type,
+      record.status,
+      record.priority,
+      record.concurrencyKey,
+      record.dedupeKey,
+      record.payloadJson,
+      record.resultJson,
+      record.errorJson,
+      record.attempts,
+      record.maxAttempts,
+      record.lockedAt,
+      record.workerId,
+      record.startedAt,
+      record.completedAt,
+      record.supersededByJobId,
+      record.ackMessageId,
+      record.progressMessageId,
+      record.createdAt,
+      record.updatedAt,
+    );
+
+    return record;
+  }
+
+  async findByDedupeKey(dedupeKey: string): Promise<JobRecord | undefined> {
+    const row = await this.db.get(`SELECT * FROM jobs WHERE dedupe_key = ?`, dedupeKey);
+    return row ? this.mapJobRecord(row) : undefined;
+  }
+
+  async findById(jobId: string): Promise<JobRecord | undefined> {
+    const row = await this.db.get(`SELECT * FROM jobs WHERE id = ?`, jobId);
+    return row ? this.mapJobRecord(row) : undefined;
+  }
+
+  async listQueuedJobs(): Promise<JobRecord[]> {
+    const rows = await this.db.all(
+      `
+        SELECT * FROM jobs
+        WHERE status = 'queued'
+        ORDER BY priority ASC, created_at ASC
+      `,
+    );
+    return rows.map((row) => this.mapJobRecord(row));
+  }
+
+  async hasRunningJobForConcurrencyKey(concurrencyKey: string): Promise<boolean> {
+    const row = await this.db.get(
+      `
+        SELECT COUNT(*) as count
+        FROM jobs
+        WHERE concurrency_key = ?
+          AND status = 'running'
+      `,
+      concurrencyKey,
+    );
+    return (row?.count || 0) > 0;
+  }
+
+  async claim(jobId: string, workerId: string): Promise<JobRecord | undefined> {
+    const now = new Date().toISOString();
+    const result = await this.db.run(
+      `
+        UPDATE jobs
+        SET status = 'running',
+            locked_at = ?,
+            worker_id = ?,
+            started_at = COALESCE(started_at, ?),
+            attempts = attempts + 1,
+            updated_at = ?
+        WHERE id = ?
+          AND status = 'queued'
+      `,
+      now,
+      workerId,
+      now,
+      now,
+      jobId,
+    );
+
+    if (!result.changes) {
+      return undefined;
+    }
+
+    return this.findById(jobId);
+  }
+
+  async markCompleted(
+    jobId: string,
+    resultPayload: Record<string, unknown>,
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db.run(
+      `
+        UPDATE jobs
+        SET status = 'completed',
+            result_json = ?,
+            error_json = NULL,
+            completed_at = ?,
+            locked_at = NULL,
+            worker_id = NULL,
+            updated_at = ?
+        WHERE id = ?
+      `,
+      JSON.stringify(resultPayload),
+      now,
+      now,
+      jobId,
+    );
+  }
+
+  async markFailed(
+    jobId: string,
+    errorPayload: Record<string, unknown>,
+    terminal: boolean,
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    const nextStatus: JobStatus = terminal ? 'failed' : 'queued';
+
+    await this.db.run(
+      `
+        UPDATE jobs
+        SET status = ?,
+            error_json = ?,
+            locked_at = NULL,
+            worker_id = NULL,
+            completed_at = CASE WHEN ? = 'failed' THEN ? ELSE completed_at END,
+            updated_at = ?
+        WHERE id = ?
+      `,
+      nextStatus,
+      JSON.stringify(errorPayload),
+      nextStatus,
+      now,
+      now,
+      jobId,
+    );
+  }
+
+  async markSuperseded(jobId: string, supersededByJobId: string): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db.run(
+      `
+        UPDATE jobs
+        SET status = 'superseded',
+            superseded_by_job_id = ?,
+            completed_at = ?,
+            updated_at = ?
+        WHERE id = ?
+          AND status = 'queued'
+      `,
+      supersededByJobId,
+      now,
+      now,
+      jobId,
+    );
+  }
+
+  async supersedeQueuedJobsByDedupeKey(dedupeKey: string, supersededByJobId: string): Promise<void> {
+    const rows = await this.db.all(
+      `
+        SELECT id FROM jobs
+        WHERE dedupe_key = ?
+          AND status = 'queued'
+      `,
+      dedupeKey,
+    );
+
+    for (const row of rows) {
+      if (row.id !== supersededByJobId) {
+        await this.markSuperseded(row.id, supersededByJobId);
+      }
+    }
+  }
+
+  async updateAcknowledgementMessage(jobId: string, ackMessageId: number): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db.run(
+      `
+        UPDATE jobs
+        SET ack_message_id = ?, updated_at = ?
+        WHERE id = ?
+      `,
+      ackMessageId,
+      now,
+      jobId,
+    );
+  }
+
+  async updateProgressMessage(jobId: string, progressMessageId: number): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db.run(
+      `
+        UPDATE jobs
+        SET progress_message_id = ?, updated_at = ?
+        WHERE id = ?
+      `,
+      progressMessageId,
+      now,
+      jobId,
+    );
+  }
+
+  async requeueStaleRunningJobs(staleBeforeIso: string): Promise<number> {
+    const now = new Date().toISOString();
+    const result = await this.db.run(
+      `
+        UPDATE jobs
+        SET status = 'queued',
+            locked_at = NULL,
+            worker_id = NULL,
+            updated_at = ?
+        WHERE status = 'running'
+          AND locked_at IS NOT NULL
+          AND locked_at < ?
+          AND attempts < max_attempts
+      `,
+      now,
+      staleBeforeIso,
+    );
+    return result.changes || 0;
+  }
+
+  async getStatusCounts(): Promise<{ queued: number; running: number }> {
+    const rows = await this.db.all(
+      `
+        SELECT status, COUNT(*) as count
+        FROM jobs
+        WHERE status IN ('queued', 'running')
+        GROUP BY status
+      `,
+    );
+
+    const counts = {
+      queued: 0,
+      running: 0,
+    };
+
+    for (const row of rows) {
+      const status = String(row.status) as 'queued' | 'running';
+      counts[status] = Number(row.count);
+    }
+
+    return counts;
+  }
+
+  private mapJobRecord(row: Record<string, unknown>): JobRecord {
+    return {
+      id: String(row.id),
+      userId: Number(row.user_id),
+      chatId: Number(row.chat_id),
+      messageId: Number(row.message_id),
+      type: row.type as JobType,
+      status: row.status as JobStatus,
+      priority: Number(row.priority),
+      concurrencyKey: row.concurrency_key ? String(row.concurrency_key) : null,
+      dedupeKey: String(row.dedupe_key),
+      payloadJson: String(row.payload_json),
+      resultJson: row.result_json ? String(row.result_json) : null,
+      errorJson: row.error_json ? String(row.error_json) : null,
+      attempts: Number(row.attempts),
+      maxAttempts: Number(row.max_attempts),
+      lockedAt: row.locked_at ? String(row.locked_at) : null,
+      workerId: row.worker_id ? String(row.worker_id) : null,
+      startedAt: row.started_at ? String(row.started_at) : null,
+      completedAt: row.completed_at ? String(row.completed_at) : null,
+      supersededByJobId: row.superseded_by_job_id ? String(row.superseded_by_job_id) : null,
+      ackMessageId: row.ack_message_id ? Number(row.ack_message_id) : null,
+      progressMessageId: row.progress_message_id ? Number(row.progress_message_id) : null,
+      createdAt: String(row.created_at),
+      updatedAt: String(row.updated_at),
+    };
+  }
+}

--- a/src/repositories/message.repository.ts
+++ b/src/repositories/message.repository.ts
@@ -1,0 +1,45 @@
+import { Database } from 'sqlite';
+import sqlite3 from 'sqlite3';
+import { InboundTask, MessageRecord } from '../types/job.types';
+
+export class MessageRepository {
+  constructor(private readonly db: Database<sqlite3.Database, sqlite3.Statement>) {}
+
+  async create(task: InboundTask): Promise<MessageRecord> {
+    const now = new Date().toISOString();
+    const result = await this.db.run(
+      `
+        INSERT INTO messages (
+          telegram_update_id,
+          telegram_message_id,
+          chat_id,
+          user_id,
+          message_type,
+          payload_json,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      task.telegramUpdateId,
+      task.telegramMessageId,
+      task.chatId,
+      task.userId,
+      task.kind,
+      JSON.stringify(task),
+      now,
+      now,
+    );
+
+    return {
+      id: result.lastID!,
+      telegramUpdateId: task.telegramUpdateId,
+      telegramMessageId: task.telegramMessageId,
+      chatId: task.chatId,
+      userId: task.userId,
+      messageType: task.kind,
+      payloadJson: JSON.stringify(task),
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,39 +2,50 @@
 import express, { Request, Response, NextFunction } from 'express';
 import { logger } from './utils/logger';
 import { createWebhookRouter } from './controllers/webhook.controller';
-import { botService } from './app';
+import { initializeApplication } from './app';
 
 const NGROK_URL = process.env.NGROK_URL!;
 const TELEGRAM_SECRET_TOKEN = process.env.TELEGRAM_SECRET_TOKEN!;
 
-// Register webhook with Telegram (runs once per URL; safe to call on every start)
-(async () => {
+async function bootstrap() {
+  const { botService, workerService, sqliteService } = await initializeApplication();
+
   try {
     await botService.setupWebhook(NGROK_URL, TELEGRAM_SECRET_TOKEN);
   } catch (err) {
     logger.error('Error setting up webhook:', err);
   }
-})();
 
-// Express app
-const app = express();
-app.use(express.json());
+  const app = express();
+  app.use(express.json());
 
-app.get('/ping', (_req: Request, res: Response, _next: NextFunction) => {
-  res.json({ status: 'ok' });
-});
+  app.get('/ping', (_req: Request, res: Response, _next: NextFunction) => {
+    res.json({ status: 'ok' });
+  });
 
-app.use(createWebhookRouter(botService));
+  app.use(createWebhookRouter(botService));
 
-// Start listening
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  logger.info(`Server started at http://localhost:${PORT}`);
-  logger.info(`Waiting for Telegram updates on /webhook/:secret`);
-});
+  workerService.start();
 
-// Graceful shutdown
-process.on('SIGTERM', () => {
-  logger.info('Shutting down gracefully...');
-  process.exit(0);
-});
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    logger.info(`Server started at http://localhost:${PORT}`);
+    logger.info(`Waiting for Telegram updates on /webhook/:secret`);
+  });
+
+  const shutdown = async () => {
+    logger.info('Shutting down gracefully...');
+    await workerService.stop();
+    await sqliteService.close();
+    process.exit(0);
+  };
+
+  process.on('SIGTERM', () => {
+    void shutdown();
+  });
+  process.on('SIGINT', () => {
+    void shutdown();
+  });
+}
+
+void bootstrap();

--- a/src/services/ai/gpt.service.ts
+++ b/src/services/ai/gpt.service.ts
@@ -22,6 +22,11 @@ import { GPTValidator } from './validators/gpt.validator';
 import { GPTErrorHandler } from './errors/gpt-error-handler.service';
 import { FunctionCallingProcessor } from './processors/function-calling.processor';
 import { SimpleTextProcessor } from './processors/simple-text.processor';
+import { ProcessingHooks } from '../../types/processing.types';
+
+export interface GPTProcessingContext extends ProcessingHooks {
+  jobId?: string;
+}
 
 /**
  * Service for generating text content using OpenAI GPT models with function calling
@@ -78,10 +83,15 @@ export class GPTService {
    * @param userId - User identifier for context/authorization
    * @returns Promise<string> - The final response to send back to user
    */
-  async processMessage(message: string, userId?: string): Promise<string> {
+  async processMessage(
+    message: string,
+    userId?: string,
+    context?: GPTProcessingContext,
+  ): Promise<string> {
     const startTime = Date.now();
 
     logger.info('Processing message with GPT', {
+      jobId: context?.jobId,
       userId,
       messageLength: message.length,
       functionCallingEnabled: this.enableFunctionCalling,
@@ -103,6 +113,7 @@ export class GPTService {
             this.config.temperature,
             message,
             userId || 'anonymous',
+            context,
           );
           return result.response;
         }
@@ -121,6 +132,7 @@ export class GPTService {
         if (attempt < MAX_RETRIES && GPTErrorHandler.isRetryableError(lastError)) {
           const delay = GPTErrorHandler.getRetryDelay(attempt);
           logger.warn('Retryable error encountered, retrying', {
+            jobId: context?.jobId,
             userId,
             attempt,
             delayMs: delay,
@@ -137,6 +149,7 @@ export class GPTService {
     const processingTimeMs = Date.now() - startTime;
 
     logger.error('Message processing failed', {
+      jobId: context?.jobId,
       userId,
       messageLength: message.length,
       error: lastError!.message,

--- a/src/services/ai/processors/function-calling.processor.ts
+++ b/src/services/ai/processors/function-calling.processor.ts
@@ -11,6 +11,7 @@ import { GPT_CONSTANTS } from '../constants/gpt.constants';
 import { getFunctionCallingSystemPrompt, FINAL_RESPONSE_PROMPT } from '../../../types/gpt.prompts';
 import { GPTToolsService } from '../../tools/todoist-tools.service';
 import { ToolDispatcher, ToolCall } from '../../../types/tool.types';
+import { GPTProcessingContext } from '../gpt.service';
 
 /**
  * Processor for handling GPT function calling capabilities
@@ -38,6 +39,7 @@ export class FunctionCallingProcessor {
     temperature: number,
     message: string,
     userId: string,
+    context?: GPTProcessingContext,
   ): Promise<MessageProcessingResult> {
     const startTime = Date.now();
 
@@ -80,6 +82,7 @@ export class FunctionCallingProcessor {
           temperature,
           message,
           userId,
+          context,
         );
 
         return {
@@ -132,6 +135,7 @@ export class FunctionCallingProcessor {
     temperature: number,
     originalMessage: string,
     userId: string,
+    context?: GPTProcessingContext,
   ): Promise<string> {
     if (!this.toolDispatcher || !responseMessage.tool_calls) {
       return "I'd like to help you with that, but I'm currently unable to execute the required actions.";
@@ -149,6 +153,7 @@ export class FunctionCallingProcessor {
       }));
 
       logger.info('Executing tool calls', {
+        jobId: context?.jobId,
         userId,
         toolCalls: toolCalls.map((tc) => ({
           id: tc.id,
@@ -168,10 +173,16 @@ export class FunctionCallingProcessor {
       }
 
       // Execute all supported tool calls
-      const toolResults = await this.toolDispatcher.executeToolCalls(supportedCalls, userId);
+      await context?.onStage?.('tools.executing');
+      const toolResults = await this.toolDispatcher.executeToolCalls(supportedCalls, {
+        userId,
+        jobId: context?.jobId,
+        onStage: context?.onStage,
+      });
 
       // Log execution results
       logger.info('Tool execution completed', {
+        jobId: context?.jobId,
         userId,
         results: toolResults.map((result) => ({
           tool_call_id: result.tool_call_id,
@@ -193,6 +204,7 @@ export class FunctionCallingProcessor {
       return finalResponse;
     } catch (error) {
       logger.error('Tool call execution failed', {
+        jobId: context?.jobId,
         userId,
         error: (error as Error).message,
       });

--- a/src/services/jobs/job-progress.service.ts
+++ b/src/services/jobs/job-progress.service.ts
@@ -1,0 +1,33 @@
+import { JobEventRepository } from '../../repositories/job-event.repository';
+import { JobRepository } from '../../repositories/job.repository';
+import { JobProgressReporter, JobRecord } from '../../types/job.types';
+import { TelegramProgressService } from '../telegram/telegram-progress.service';
+
+export class JobProgressService {
+  constructor(
+    private readonly jobEventRepository: JobEventRepository,
+    private readonly jobRepository: JobRepository,
+    private readonly telegramProgressService: TelegramProgressService,
+  ) {}
+
+  createReporter(jobId: string): JobProgressReporter {
+    return {
+      report: async (eventType: string, message?: string, payload?: Record<string, unknown>) => {
+        await this.record(jobId, eventType, message, payload);
+      },
+    };
+  }
+
+  async record(
+    jobId: string,
+    eventType: string,
+    message?: string,
+    payload?: Record<string, unknown>,
+  ): Promise<void> {
+    await this.jobEventRepository.create(jobId, eventType, message, payload);
+    const job = await this.jobRepository.findById(jobId);
+    if (job) {
+      await this.telegramProgressService.updateProgress(job, eventType, message);
+    }
+  }
+}

--- a/src/services/jobs/job-queue.service.ts
+++ b/src/services/jobs/job-queue.service.ts
@@ -1,0 +1,32 @@
+import { JobRepository } from '../../repositories/job.repository';
+import { JobRecord } from '../../types/job.types';
+import { JobSchedulerService } from './job-scheduler.service';
+
+export class JobQueueService {
+  constructor(
+    private readonly jobRepository: JobRepository,
+    private readonly jobSchedulerService: JobSchedulerService,
+  ) {}
+
+  async requeueStaleJobs(lockTimeoutMs: number): Promise<number> {
+    const staleBefore = new Date(Date.now() - lockTimeoutMs).toISOString();
+    return this.jobRepository.requeueStaleRunningJobs(staleBefore);
+  }
+
+  async claimNextRunnableJob(workerId: string): Promise<JobRecord | undefined> {
+    const queuedJobs = await this.jobRepository.listQueuedJobs();
+
+    for (const job of queuedJobs) {
+      if (!(await this.jobSchedulerService.canRun(job))) {
+        continue;
+      }
+
+      const claimed = await this.jobRepository.claim(job.id, workerId);
+      if (claimed) {
+        return claimed;
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/src/services/jobs/job-scheduler.service.ts
+++ b/src/services/jobs/job-scheduler.service.ts
@@ -1,0 +1,14 @@
+import { JobRecord } from '../../types/job.types';
+import { JobRepository } from '../../repositories/job.repository';
+
+export class JobSchedulerService {
+  constructor(private readonly jobRepository: JobRepository) {}
+
+  async canRun(job: JobRecord): Promise<boolean> {
+    if (!job.concurrencyKey) {
+      return true;
+    }
+
+    return !(await this.jobRepository.hasRunningJobForConcurrencyKey(job.concurrencyKey));
+  }
+}

--- a/src/services/jobs/job-worker.service.ts
+++ b/src/services/jobs/job-worker.service.ts
@@ -1,0 +1,154 @@
+import { logger } from '../../utils/logger';
+import { JobQueueService } from './job-queue.service';
+import { JobProgressService } from './job-progress.service';
+import { JobService } from './job.service';
+import { JobPayload, JobProcessor, JobRecord } from '../../types/job.types';
+import { TelegramResponseService } from '../telegram/telegram-response.service';
+
+interface JobWorkerServiceOptions {
+  pollIntervalMs?: number;
+  concurrency?: number;
+  lockTimeoutMs?: number;
+}
+
+export class JobWorkerService {
+  private readonly workerId = `worker-${process.pid}`;
+  private readonly pollIntervalMs: number;
+  private readonly concurrency: number;
+  private readonly lockTimeoutMs: number;
+  private readonly processors = new Map<JobRecord['type'], JobProcessor>();
+  private timer?: NodeJS.Timeout;
+  private isRunning = false;
+  private activeJobs = 0;
+
+  constructor(
+    private readonly jobQueueService: JobQueueService,
+    private readonly jobProgressService: JobProgressService,
+    private readonly jobService: JobService,
+    private readonly telegramResponseService: TelegramResponseService,
+    options: JobWorkerServiceOptions = {},
+  ) {
+    this.pollIntervalMs = options.pollIntervalMs ?? 250;
+    this.concurrency = options.concurrency ?? 2;
+    this.lockTimeoutMs = options.lockTimeoutMs ?? 30_000;
+  }
+
+  registerProcessor(type: JobRecord['type'], processor: JobProcessor): void {
+    this.processors.set(type, processor);
+  }
+
+  start(): void {
+    if (this.timer) {
+      return;
+    }
+
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.pollIntervalMs);
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+
+    while (this.activeJobs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  async runOnce(): Promise<boolean> {
+    if (this.isRunning || this.activeJobs >= this.concurrency) {
+      return false;
+    }
+
+    this.isRunning = true;
+
+    try {
+      await this.jobQueueService.requeueStaleJobs(this.lockTimeoutMs);
+      const job = await this.jobQueueService.claimNextRunnableJob(this.workerId);
+      if (!job) {
+        return false;
+      }
+
+      this.activeJobs += 1;
+      void this.executeJob(job).finally(() => {
+        this.activeJobs -= 1;
+      });
+
+      return true;
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  private async tick(): Promise<void> {
+    while (this.activeJobs < this.concurrency) {
+      const claimed = await this.runOnce();
+      if (!claimed) {
+        break;
+      }
+    }
+  }
+
+  private async executeJob(job: JobRecord): Promise<void> {
+    const processor = this.processors.get(job.type);
+    if (!processor) {
+      await this.failJob(job, new Error(`No processor registered for job type ${job.type}`));
+      return;
+    }
+
+    const progressReporter = this.jobProgressService.createReporter(job.id);
+
+    try {
+      logger.info('Job claimed', {
+        jobId: job.id,
+        userId: job.userId,
+        chatId: job.chatId,
+        jobType: job.type,
+        attempt: job.attempts,
+      });
+
+      const result = await processor.process({
+        job,
+        payload: JSON.parse(job.payloadJson) as JobPayload,
+        progressReporter,
+        cancellationState: {
+          isCancelled: async () => {
+            const latest = await this.jobService.findById(job.id);
+            return !!latest && ['cancelled', 'superseded'].includes(latest.status);
+          },
+        },
+      });
+
+      await this.jobProgressService.record(job.id, 'job.completed');
+      await this.telegramResponseService.sendFinalResponse(job.chatId, result.finalMessage);
+      await this.jobService.markCompleted(job.id, result.finalMessage);
+    } catch (error) {
+      await this.failJob(job, error as Error);
+    }
+  }
+
+  private async failJob(job: JobRecord, error: Error): Promise<void> {
+    logger.error('Job execution failed', {
+      jobId: job.id,
+      userId: job.userId,
+      chatId: job.chatId,
+      jobType: job.type,
+      attempt: job.attempts,
+      error: error.message,
+    });
+
+    await this.jobProgressService.record(job.id, 'job.failed', error.message);
+    await this.jobService.markFailed(job, error);
+
+    const latest = await this.jobService.findById(job.id);
+    if (latest?.status === 'failed') {
+      await this.telegramResponseService.sendFailureResponse(
+        job.chatId,
+        '❌ Sorry, I had trouble processing your request.',
+      );
+    }
+  }
+}

--- a/src/services/jobs/job.service.ts
+++ b/src/services/jobs/job.service.ts
@@ -1,0 +1,98 @@
+import { JobRepository } from '../../repositories/job.repository';
+import {
+  EnqueuedJob,
+  InboundTask,
+  JobPayload,
+  JobRecord,
+} from '../../types/job.types';
+import { MessageRepository } from '../../repositories/message.repository';
+import { logger } from '../../utils/logger';
+
+export class JobService {
+  constructor(
+    private readonly messageRepository: MessageRepository,
+    private readonly jobRepository: JobRepository,
+  ) {}
+
+  async enqueue(task: InboundTask): Promise<EnqueuedJob> {
+    const dedupeKey = `${task.userId}:${task.telegramUpdateId}:${task.kind}`;
+    const existing = await this.jobRepository.findByDedupeKey(dedupeKey);
+    if (existing) {
+      return {
+        job: existing,
+        acknowledgement: this.getAcknowledgement(existing.type),
+      };
+    }
+
+    const message = await this.messageRepository.create(task);
+    const payload: JobPayload = {
+      text: task.text,
+      fileId: task.fileId,
+      fileName: task.fileName,
+      mimeType: task.mimeType,
+      duration: task.duration,
+      metadata: task.metadata,
+    };
+
+    const job = await this.jobRepository.create({
+      userId: task.userId,
+      chatId: task.chatId,
+      messageId: message.id,
+      type: task.kind,
+      concurrencyKey: null,
+      dedupeKey,
+      payload,
+      maxAttempts: 2,
+    });
+
+    logger.info('Job created', {
+      jobId: job.id,
+      userId: job.userId,
+      chatId: job.chatId,
+      telegramUpdateId: task.telegramUpdateId,
+      jobType: job.type,
+    });
+
+    return {
+      job,
+      acknowledgement: this.getAcknowledgement(job.type),
+    };
+  }
+
+  async attachAcknowledgement(jobId: string, ackMessageId: number): Promise<void> {
+    await this.jobRepository.updateAcknowledgementMessage(jobId, ackMessageId);
+  }
+
+  async markCompleted(jobId: string, finalMessage: string): Promise<void> {
+    await this.jobRepository.markCompleted(jobId, { finalMessage });
+  }
+
+  async markFailed(job: JobRecord, error: Error): Promise<void> {
+    const terminal = job.attempts >= job.maxAttempts;
+    await this.jobRepository.markFailed(
+      job.id,
+      { message: error.message, stack: error.stack },
+      terminal,
+    );
+  }
+
+  async findById(jobId: string): Promise<JobRecord | undefined> {
+    return this.jobRepository.findById(jobId);
+  }
+
+  async getSnapshot(): Promise<{ queued: number; running: number }> {
+    return this.jobRepository.getStatusCounts();
+  }
+
+  private getAcknowledgement(type: JobRecord['type']): string {
+    switch (type) {
+      case 'voice':
+        return 'Voice note received. I’m transcribing it now.';
+      case 'audio_document':
+        return 'Audio file received. I’m processing it now.';
+      case 'text':
+      default:
+        return 'Received. Working on it.';
+    }
+  }
+}

--- a/src/services/jobs/processors/audio-job.processor.ts
+++ b/src/services/jobs/processors/audio-job.processor.ts
@@ -1,0 +1,53 @@
+import { MessageProcessorService } from '../../telegram/message-processor.service';
+import { FileService } from '../../telegram/file.service';
+import { JobContext, JobExecutionResult, JobProcessor } from '../../../types/job.types';
+
+export class AudioJobProcessor implements JobProcessor {
+  constructor(
+    private readonly messageProcessor: MessageProcessorService,
+    private readonly fileService: FileService,
+  ) {}
+
+  async process(context: JobContext): Promise<JobExecutionResult> {
+    await context.progressReporter.report('job.started');
+    await context.progressReporter.report('media.downloading');
+
+    const fileId = context.payload.fileId;
+    if (!fileId) {
+      throw new Error('Audio job is missing file_id');
+    }
+
+    const fileUrl = await this.fileService.getFileUrl(fileId);
+    const finalMessage =
+      context.job.type === 'audio_document'
+        ? await this.messageProcessor.processAudioDocument(
+            fileUrl,
+            context.payload.fileName || 'audio_file',
+            context.payload.mimeType || 'application/octet-stream',
+            context.job.userId,
+            {
+              onStage: async (eventType, message) => {
+                await context.progressReporter.report(eventType, message);
+              },
+            },
+            context.job.id,
+          )
+        : await this.messageProcessor.processAudioMessage(
+            fileUrl,
+            context.job.userId,
+            {
+              onStage: async (eventType, message) => {
+                await context.progressReporter.report(eventType, message);
+              },
+            },
+            context.job.id,
+          );
+
+    return {
+      finalMessage,
+      metrics: {
+        attempts: context.job.attempts,
+      },
+    };
+  }
+}

--- a/src/services/jobs/processors/text-job.processor.ts
+++ b/src/services/jobs/processors/text-job.processor.ts
@@ -1,0 +1,29 @@
+import { MessageProcessorService } from '../../telegram/message-processor.service';
+import { JobContext, JobExecutionResult, JobProcessor } from '../../../types/job.types';
+
+export class TextJobProcessor implements JobProcessor {
+  constructor(private readonly messageProcessor: MessageProcessorService) {}
+
+  async process(context: JobContext): Promise<JobExecutionResult> {
+    await context.progressReporter.report('job.started');
+    await context.progressReporter.report('gpt.processing');
+
+    const finalMessage = await this.messageProcessor.processTextMessage(
+      context.payload.text || '',
+      context.job.userId,
+      {
+        onStage: async (eventType, message) => {
+          await context.progressReporter.report(eventType, message);
+        },
+      },
+      context.job.id,
+    );
+
+    return {
+      finalMessage,
+      metrics: {
+        attempts: context.job.attempts,
+      },
+    };
+  }
+}

--- a/src/services/persistence/sqlite.service.ts
+++ b/src/services/persistence/sqlite.service.ts
@@ -1,0 +1,106 @@
+import path from 'path';
+import { mkdir } from 'fs/promises';
+import sqlite3 from 'sqlite3';
+import { Database, open } from 'sqlite';
+
+export class SQLiteService {
+  private db?: Database<sqlite3.Database, sqlite3.Statement>;
+
+  constructor(
+    private readonly databasePath =
+      process.env.SQLITE_PATH || path.join(process.cwd(), 'data', 'jarvis.sqlite'),
+  ) {}
+
+  async initialize(): Promise<void> {
+    const databaseDirectory = path.dirname(this.databasePath);
+    await mkdir(databaseDirectory, { recursive: true });
+
+    this.db = await open({
+      filename: this.databasePath,
+      driver: sqlite3.Database,
+    });
+
+    await this.db.exec('PRAGMA journal_mode = WAL;');
+    await this.db.exec('PRAGMA foreign_keys = ON;');
+    await this.runMigrations();
+  }
+
+  getDatabase(): Database<sqlite3.Database, sqlite3.Statement> {
+    if (!this.db) {
+      throw new Error('SQLiteService has not been initialized');
+    }
+
+    return this.db;
+  }
+
+  async close(): Promise<void> {
+    if (this.db) {
+      await this.db.close();
+      this.db = undefined;
+    }
+  }
+
+  private async runMigrations(): Promise<void> {
+    const db = this.getDatabase();
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        telegram_update_id INTEGER NOT NULL UNIQUE,
+        telegram_message_id INTEGER NOT NULL,
+        chat_id INTEGER NOT NULL,
+        user_id INTEGER NOT NULL,
+        message_type TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+
+      CREATE TABLE IF NOT EXISTS jobs (
+        id TEXT PRIMARY KEY,
+        user_id INTEGER NOT NULL,
+        chat_id INTEGER NOT NULL,
+        message_id INTEGER NOT NULL,
+        type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        priority INTEGER NOT NULL DEFAULT 100,
+        concurrency_key TEXT,
+        dedupe_key TEXT NOT NULL UNIQUE,
+        payload_json TEXT NOT NULL,
+        result_json TEXT,
+        error_json TEXT,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        max_attempts INTEGER NOT NULL DEFAULT 2,
+        locked_at TEXT,
+        worker_id TEXT,
+        started_at TEXT,
+        completed_at TEXT,
+        superseded_by_job_id TEXT,
+        ack_message_id INTEGER,
+        progress_message_id INTEGER,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (message_id) REFERENCES messages(id)
+      );
+
+      CREATE TABLE IF NOT EXISTS job_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        job_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        message TEXT,
+        payload_json TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (job_id) REFERENCES jobs(id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_jobs_status_priority_created_at
+      ON jobs(status, priority, created_at);
+
+      CREATE INDEX IF NOT EXISTS idx_jobs_concurrency_key_status
+      ON jobs(concurrency_key, status);
+
+      CREATE INDEX IF NOT EXISTS idx_job_events_job_id_created_at
+      ON job_events(job_id, created_at);
+    `);
+  }
+}

--- a/src/services/telegram/bot-status.service.ts
+++ b/src/services/telegram/bot-status.service.ts
@@ -5,6 +5,12 @@ import { BotActivityService } from './bot-activity.service';
 export interface BotStatusServiceOptions {
   gptModel?: string;
   todoistService?: Pick<TodoistAPIService, 'getProjects'>;
+  queueSnapshotProvider?: {
+    getSnapshot(): Promise<{
+      queued: number;
+      running: number;
+    }>;
+  };
 }
 
 export interface BotStatusSnapshot {
@@ -25,6 +31,10 @@ export interface BotStatusSnapshot {
     lastActivityAt: Date | null;
     lastActivityType: string | null;
   };
+  queue: {
+    queued: number;
+    running: number;
+  };
 }
 
 /**
@@ -33,6 +43,7 @@ export interface BotStatusSnapshot {
 export class BotStatusService {
   private readonly gptModel: string;
   private readonly todoistService?: Pick<TodoistAPIService, 'getProjects'>;
+  private readonly queueSnapshotProvider?: BotStatusServiceOptions['queueSnapshotProvider'];
 
   constructor(
     private readonly activityService: BotActivityService,
@@ -40,11 +51,13 @@ export class BotStatusService {
   ) {
     this.gptModel = options.gptModel || GPT_CONSTANTS.DEFAULT_MODEL;
     this.todoistService = options.todoistService;
+    this.queueSnapshotProvider = options.queueSnapshotProvider;
   }
 
   async getSnapshot(): Promise<BotStatusSnapshot> {
     const activity = this.activityService.getSnapshot();
     const todoist = await this.getTodoistStatus();
+    const queue = await this.getQueueSnapshot();
 
     return {
       runtime: {
@@ -61,6 +74,7 @@ export class BotStatusService {
         lastActivityAt: activity.lastActivityAt,
         lastActivityType: activity.lastActivityType,
       },
+      queue,
     };
   }
 
@@ -82,11 +96,26 @@ export class BotStatusService {
       `*Dependencies*`,
       `• Todoist: ${snapshot.todoist.ok ? 'reachable' : 'degraded'} (${snapshot.todoist.detail})`,
       '',
+      `*Queue*`,
+      `• Queued jobs: ${snapshot.queue.queued}`,
+      `• Running jobs: ${snapshot.queue.running}`,
+      '',
       `*Recent Activity*`,
       `• Total interactions: ${snapshot.activity.totalInteractions}`,
       `• Last activity: ${this.formatLastActivity(snapshot.activity.lastActivityAt)}`,
       `• Last activity type: ${snapshot.activity.lastActivityType || 'none yet'}`,
     ].join('\n');
+  }
+
+  private async getQueueSnapshot(): Promise<BotStatusSnapshot['queue']> {
+    if (!this.queueSnapshotProvider) {
+      return {
+        queued: 0,
+        running: 0,
+      };
+    }
+
+    return this.queueSnapshotProvider.getSnapshot();
   }
 
   private async getTodoistStatus(): Promise<BotStatusSnapshot['todoist']> {

--- a/src/services/telegram/handlers/message-handlers.ts
+++ b/src/services/telegram/handlers/message-handlers.ts
@@ -2,8 +2,10 @@
 import { Context } from 'telegraf';
 import { logger } from '../../../utils/logger';
 import { FileService } from '../file.service';
-import { MessageProcessorService } from '../message-processor.service';
 import { BotActivityService } from '../bot-activity.service';
+import { TelegramUpdateIntakeService } from '../telegram-update-intake.service';
+import { TelegramResponseService } from '../telegram-response.service';
+import { JobService } from '../../jobs/job.service';
 
 /**
  * Handles different types of messages
@@ -11,8 +13,10 @@ import { BotActivityService } from '../bot-activity.service';
 export class MessageHandlers {
   constructor(
     private readonly fileService: FileService,
-    private readonly messageProcessor: MessageProcessorService,
+    private readonly intakeService: TelegramUpdateIntakeService,
     private readonly activityService: BotActivityService,
+    private readonly responseService: TelegramResponseService,
+    private readonly jobService: JobService,
   ) {}
 
   async handleText(ctx: Context): Promise<void> {
@@ -29,14 +33,22 @@ export class MessageHandlers {
     this.activityService.recordActivity('message_text');
 
     try {
-      const response = await this.messageProcessor.processTextMessage(messageText, userId);
-      await ctx.reply(response);
+      const enqueued = await this.intakeService.enqueueText(ctx);
+      const ack = await this.responseService.sendAcknowledgement(
+        ctx.chat!.id,
+        enqueued.acknowledgement,
+        (ctx.message as { message_id: number }).message_id,
+      );
+      await this.jobService.attachAcknowledgement(enqueued.job.id, ack.message_id);
     } catch (error) {
       logger.error('Error processing text message', {
         error: (error as Error).message,
         userId
       });
-      await ctx.reply('❌ Sorry, I had trouble processing your message.');
+      await this.responseService.sendFailureResponse(
+        ctx.chat!.id,
+        '❌ Sorry, I had trouble queuing your message.',
+      );
     }
   }
 
@@ -54,15 +66,22 @@ export class MessageHandlers {
     this.activityService.recordActivity('message_voice');
 
     try {
-      const fileUrl = await this.fileService.getFileUrl(voice.file_id);
-      const response = await this.messageProcessor.processAudioMessage(fileUrl, userId);
-      await ctx.reply(response);
+      const enqueued = await this.intakeService.enqueueVoice(ctx);
+      const ack = await this.responseService.sendAcknowledgement(
+        ctx.chat!.id,
+        enqueued.acknowledgement,
+        (ctx.message as { message_id: number }).message_id,
+      );
+      await this.jobService.attachAcknowledgement(enqueued.job.id, ack.message_id);
     } catch (error) {
       logger.error('Error processing voice message', {
         error: (error as Error).message,
         userId
       });
-      await ctx.reply('❌ Sorry, I had trouble processing your voice message.');
+      await this.responseService.sendFailureResponse(
+        ctx.chat!.id,
+        '❌ Sorry, I had trouble queuing your voice message.',
+      );
     }
   }
 
@@ -93,21 +112,23 @@ export class MessageHandlers {
       });
 
       try {
-        const fileUrl = await this.fileService.getFileUrl(document.file_id);
-        const response = await this.messageProcessor.processAudioDocument(
-          fileUrl,
-          fileName,
-          mimeType,
-          userId,
+        const enqueued = await this.intakeService.enqueueAudioDocument(ctx);
+        const ack = await this.responseService.sendAcknowledgement(
+          ctx.chat!.id,
+          enqueued.acknowledgement,
+          (ctx.message as { message_id: number }).message_id,
         );
-        await ctx.reply(response);
+        await this.jobService.attachAcknowledgement(enqueued.job.id, ack.message_id);
       } catch (error) {
         logger.error('Error processing audio document', {
           error: (error as Error).message,
           userId,
           fileName,
         });
-        await ctx.reply('❌ Sorry, I had trouble processing your audio document.');
+        await this.responseService.sendFailureResponse(
+          ctx.chat!.id,
+          '❌ Sorry, I had trouble queuing your audio document.',
+        );
       }
     } else {
       logger.info('Non-audio document received', {
@@ -115,7 +136,10 @@ export class MessageHandlers {
         mimeType: document.mime_type,
         fileName: document.file_name
       });
-      await ctx.reply('📄 I received a document, but I only process audio files. Please send an audio file.');
+      await this.responseService.sendFailureResponse(
+        ctx.chat!.id,
+        '📄 I received a document, but I only process audio files. Please send an audio file.',
+      );
     }
   }
 
@@ -128,7 +152,8 @@ export class MessageHandlers {
     });
     this.activityService.recordActivity('message_unknown');
 
-    await ctx.reply(
+    await this.responseService.sendFailureResponse(
+      ctx.chat!.id,
       '🤔 I received your message, but I don\'t know how to handle this type yet. Try sending text or audio!'
     );
   }
@@ -147,16 +172,23 @@ export class MessageHandlers {
     });
 
     try {
-      const fileUrl = await this.fileService.getFileUrl(audioFile.file_id);
-      const response = await this.messageProcessor.processAudioMessage(fileUrl, userId);
-      await ctx.reply(response);
+      const enqueued = await this.intakeService.enqueueAudio(ctx);
+      const ack = await this.responseService.sendAcknowledgement(
+        ctx.chat!.id,
+        enqueued.acknowledgement,
+        (ctx.message as { message_id: number }).message_id,
+      );
+      await this.jobService.attachAcknowledgement(enqueued.job.id, ack.message_id);
     } catch (error) {
       logger.error('Error processing audio file', {
         error: (error as Error).message,
         userId,
         fileName
       });
-      await ctx.reply('❌ Sorry, I had trouble processing your audio file.');
+      await this.responseService.sendFailureResponse(
+        ctx.chat!.id,
+        '❌ Sorry, I had trouble queuing your audio file.',
+      );
     }
   }
 }

--- a/src/services/telegram/handlers/telegram-handlers.ts
+++ b/src/services/telegram/handlers/telegram-handlers.ts
@@ -1,11 +1,13 @@
 // src/services/telegram/handlers/telegram-handlers.ts
 import { Telegraf, Context } from 'telegraf';
 import { FileService } from '../file.service';
-import { MessageProcessorService } from '../message-processor.service';
 import { CommandHandlers } from '../handlers/command-handlers';
 import { MessageHandlers } from '../handlers/message-handlers';
 import { BotActivityService } from '../bot-activity.service';
 import { BotStatusService } from '../bot-status.service';
+import { TelegramUpdateIntakeService } from '../telegram-update-intake.service';
+import { TelegramResponseService } from '../telegram-response.service';
+import { JobService } from '../../jobs/job.service';
 
 /**
  * Centralizes all Telegram bot handlers
@@ -16,12 +18,20 @@ export class TelegramHandlers {
 
   constructor(
     fileService: FileService,
-    messageProcessor: MessageProcessorService,
+    intakeService: TelegramUpdateIntakeService,
     activityService: BotActivityService,
     statusService: BotStatusService,
+    responseService: TelegramResponseService,
+    jobService: JobService,
   ) {
     this.commandHandlers = new CommandHandlers(activityService, statusService);
-    this.messageHandlers = new MessageHandlers(fileService, messageProcessor, activityService);
+    this.messageHandlers = new MessageHandlers(
+      fileService,
+      intakeService,
+      activityService,
+      responseService,
+      jobService,
+    );
   }
 
   setupHandlers(bot: Telegraf<Context>): void {

--- a/src/services/telegram/message-processor.service.ts
+++ b/src/services/telegram/message-processor.service.ts
@@ -3,6 +3,7 @@ import { logger } from '../../utils/logger';
 import { TextProcessorService } from './processors/text-processor.service';
 import { AudioProcessorService } from './processors/audio-processor.service';
 import { ToolDispatcher } from '../../types/tool.types';
+import { ProcessingHooks } from '../../types/processing.types';
 
 /**
  * Main service responsible for coordinating message processing
@@ -14,31 +15,43 @@ export class MessageProcessorService {
 
   constructor(toolDispatcher?: ToolDispatcher) {
     this.textProcessor = new TextProcessorService(toolDispatcher);
-    this.audioProcessor = new AudioProcessorService();
+    this.audioProcessor = new AudioProcessorService(toolDispatcher);
   }
 
   /**
    * Processes text messages from users
    */
-  async processTextMessage(text: string, userId?: number): Promise<string> {
+  async processTextMessage(
+    text: string,
+    userId?: number,
+    hooks?: ProcessingHooks,
+    jobId?: string,
+  ): Promise<string> {
     logger.info('Delegating text message processing', {
+      jobId,
       userId,
       messageLength: text.length,
     });
 
-    return this.textProcessor.processTextMessage(text, userId);
+    return this.textProcessor.processTextMessage(text, userId, hooks, jobId);
   }
 
   /**
    * Processes audio messages (voice notes, audio files)
    */
-  async processAudioMessage(fileUrl: string, userId?: number): Promise<string> {
+  async processAudioMessage(
+    fileUrl: string,
+    userId?: number,
+    hooks?: ProcessingHooks,
+    jobId?: string,
+  ): Promise<string> {
     logger.info('Delegating audio message processing', {
+      jobId,
       userId,
       fileUrl: fileUrl.substring(0, 50) + '...', // Log partial URL for privacy
     });
 
-    return this.audioProcessor.processAudioMessage(fileUrl, userId);
+    return this.audioProcessor.processAudioMessage(fileUrl, userId, hooks, jobId);
   }
 
   /**
@@ -49,14 +62,17 @@ export class MessageProcessorService {
     fileName: string,
     mimeType: string,
     userId?: number,
+    hooks?: ProcessingHooks,
+    jobId?: string,
   ): Promise<string> {
     logger.info('Delegating audio document processing', {
+      jobId,
       userId,
       fileName,
       mimeType,
     });
 
-    return this.audioProcessor.processAudioDocument(fileUrl, fileName, mimeType, userId);
+    return this.audioProcessor.processAudioDocument(fileUrl, fileName, mimeType, userId, hooks, jobId);
   }
 
   /**

--- a/src/services/telegram/processors/audio-processor.service.ts
+++ b/src/services/telegram/processors/audio-processor.service.ts
@@ -2,6 +2,8 @@
 import { logger } from '../../../utils/logger';
 import { WhisperService } from '../../ai/whisper.service';
 import { GPTService } from '../../ai/gpt.service';
+import { ToolDispatcher } from '../../../types/tool.types';
+import { ProcessingHooks } from '../../../types/processing.types';
 
 /**
  * Service responsible for processing audio messages and documents
@@ -10,7 +12,7 @@ export class AudioProcessorService {
   private readonly whisperService: WhisperService;
   private readonly gptService: GPTService;
 
-  constructor() {
+  constructor(toolDispatcher?: ToolDispatcher) {
     // Initialize WhisperService with English-only enforcement
     this.whisperService = new WhisperService({
       enforceEnglishOnly: true,
@@ -18,20 +20,27 @@ export class AudioProcessorService {
     });
 
     // Initialize GPTService for text processing
-    this.gptService = new GPTService();
+    this.gptService = new GPTService(toolDispatcher);
   }
 
   /**
    * Processes audio messages (voice notes, audio files)
    */
-  async processAudioMessage(fileUrl: string, userId?: number): Promise<string> {
+  async processAudioMessage(
+    fileUrl: string,
+    userId?: number,
+    hooks?: ProcessingHooks,
+    jobId?: string,
+  ): Promise<string> {
     logger.info('Processing audio message', {
+      jobId,
       userId,
       fileUrl: fileUrl.substring(0, 50) + '...', // Log partial URL for privacy
     });
 
     try {
       // Transcribe the audio using Whisper service
+      await hooks?.onStage?.('audio.transcribing');
       const transcriptionResult = await this.whisperService.transcribeAudio(fileUrl, userId);
 
       const { text, processingTimeMs } = transcriptionResult;
@@ -46,7 +55,11 @@ export class AudioProcessorService {
 
       // Process the transcribed text with GPT
       try {
-        const response = await this.gptService.processMessage(text, userId?.toString());
+        await hooks?.onStage?.('gpt.processing');
+        const response = await this.gptService.processMessage(text, userId?.toString(), {
+          jobId,
+          onStage: hooks?.onStage,
+        });
 
         const finalResponse =
           `📝 What you said: ${text}\n\n` +
@@ -87,8 +100,11 @@ export class AudioProcessorService {
     fileName: string,
     mimeType: string,
     userId?: number,
+    hooks?: ProcessingHooks,
+    jobId?: string,
   ): Promise<string> {
     logger.info('Processing audio document', {
+      jobId,
       userId,
       fileName,
       mimeType,
@@ -96,6 +112,7 @@ export class AudioProcessorService {
 
     try {
       // Use the same transcription logic as audio messages
+      await hooks?.onStage?.('audio.transcribing');
       const transcriptionResult = await this.whisperService.transcribeAudio(fileUrl, userId);
 
       const { text, processingTimeMs, fileSizeBytes } = transcriptionResult;
@@ -111,7 +128,11 @@ export class AudioProcessorService {
 
       // Process the transcribed text with GPT
       try {
-        const response = await this.gptService.processMessage(text, userId?.toString());
+        await hooks?.onStage?.('gpt.processing');
+        const response = await this.gptService.processMessage(text, userId?.toString(), {
+          jobId,
+          onStage: hooks?.onStage,
+        });
 
         const finalResponse =
           `📁 Audio document "${fileName}" processed successfully!\n` +

--- a/src/services/telegram/processors/text-processor.service.ts
+++ b/src/services/telegram/processors/text-processor.service.ts
@@ -2,6 +2,7 @@
 import { logger } from '../../../utils/logger';
 import { GPTService } from '../../ai';
 import { ToolDispatcher } from '../../../types/tool.types';
+import { ProcessingHooks } from '../../../types/processing.types';
 
 /**
  * Service responsible for processing text messages
@@ -17,17 +18,28 @@ export class TextProcessorService {
   /**
    * Processes text messages from users
    */
-  async processTextMessage(text: string, userId?: number): Promise<string> {
+  async processTextMessage(
+    text: string,
+    userId?: number,
+    hooks?: ProcessingHooks,
+    jobId?: string,
+  ): Promise<string> {
     logger.info('Processing text message', {
+      jobId,
       userId,
       messageLength: text.length,
     });
 
     try {
       // Process the message using GPT
-      const response = await this.gptService.processMessage(text, userId?.toString());
+      await hooks?.onStage?.('gpt.processing');
+      const response = await this.gptService.processMessage(text, userId?.toString(), {
+        jobId,
+        onStage: hooks?.onStage,
+      });
 
       logger.info('Text message processed successfully', {
+        jobId,
         userId,
         messageLength: text.length,
         responseLength: response.length,
@@ -36,6 +48,7 @@ export class TextProcessorService {
       return response;
     } catch (error) {
       logger.error('Failed to process text message', {
+        jobId,
         userId,
         messageLength: text.length,
         error: (error as Error).message,

--- a/src/services/telegram/telegram-bot.service.ts
+++ b/src/services/telegram/telegram-bot.service.ts
@@ -4,12 +4,14 @@ import { Telegraf, Context } from 'telegraf';
 import { Message } from 'telegraf/typings/core/types/typegram';
 import { TelegramHandlers } from './handlers/telegram-handlers';
 import { FileService } from './file.service';
-import { MessageProcessorService } from './message-processor.service';
 import { TelegramConfig } from '../../types/telegram.types';
 import { BotActivityService } from './bot-activity.service';
 import { BotStatusService } from './bot-status.service';
 import { TodoistAPIService } from '../external/todoist-api.service';
 import { GPT_CONSTANTS } from '../ai/constants/gpt.constants';
+import { TelegramUpdateIntakeService } from './telegram-update-intake.service';
+import { TelegramResponseService } from './telegram-response.service';
+import { JobService } from '../jobs/job.service';
 
 /**
  * Service class responsible for managing Telegram bot operations
@@ -19,30 +21,34 @@ export class TelegramBotService {
   private readonly botToken: string;
   private readonly handlers: TelegramHandlers;
   private readonly fileService: FileService;
-  private readonly messageProcessor: MessageProcessorService;
   private readonly activityService: BotActivityService;
   private readonly statusService: BotStatusService;
+  private readonly responseService: TelegramResponseService;
 
   constructor(
     config: TelegramConfig,
-    messageProcessor: MessageProcessorService
+    intakeService: TelegramUpdateIntakeService,
+    jobService?: JobService,
   ) {
     this.botToken = config.token;
     this.bot = new Telegraf(config.token);
-    this.messageProcessor = messageProcessor;
     this.fileService = new FileService(this.botToken, this.bot.telegram);
     this.activityService = new BotActivityService();
+    this.responseService = new TelegramResponseService(this.bot.telegram);
     this.statusService = new BotStatusService(this.activityService, {
       gptModel: process.env.OPENAI_MODEL || GPT_CONSTANTS.DEFAULT_MODEL,
       todoistService: process.env.TODOIST_API_KEY
         ? new TodoistAPIService(process.env.TODOIST_API_KEY)
         : undefined,
+      queueSnapshotProvider: jobService,
     });
     this.handlers = new TelegramHandlers(
       this.fileService,
-      this.messageProcessor,
+      intakeService,
       this.activityService,
       this.statusService,
+      this.responseService,
+      jobService || ({} as JobService),
     );
 
     this.setupBotHandlers();

--- a/src/services/telegram/telegram-progress.service.ts
+++ b/src/services/telegram/telegram-progress.service.ts
@@ -1,0 +1,37 @@
+import { JobRecord } from '../../types/job.types';
+import { logger } from '../../utils/logger';
+import { JobRepository } from '../../repositories/job.repository';
+import { TelegramResponseService } from './telegram-response.service';
+
+const PROGRESS_MESSAGES: Record<string, string> = {
+  'job.started': 'Working on it.',
+  'media.downloading': 'Downloading media from Telegram.',
+  'audio.transcribing': 'Transcribing your audio now.',
+  'gpt.processing': 'Thinking through the request.',
+  'tools.executing': 'Running the requested actions.',
+};
+
+export class TelegramProgressService {
+  constructor(
+    private readonly responseService: TelegramResponseService,
+    private readonly jobRepository: JobRepository,
+  ) {}
+
+  async updateProgress(job: JobRecord, eventType: string, message?: string): Promise<void> {
+    const progressText = message || PROGRESS_MESSAGES[eventType];
+    if (!progressText || !job.ackMessageId) {
+      return;
+    }
+
+    try {
+      await this.responseService.updateMessage(job.chatId, job.ackMessageId, progressText);
+      await this.jobRepository.updateProgressMessage(job.id, job.ackMessageId);
+    } catch (error) {
+      logger.debug('Progress message update skipped', {
+        jobId: job.id,
+        eventType,
+        error: (error as Error).message,
+      });
+    }
+  }
+}

--- a/src/services/telegram/telegram-response.service.ts
+++ b/src/services/telegram/telegram-response.service.ts
@@ -1,0 +1,42 @@
+import { Message } from 'telegraf/typings/core/types/typegram';
+import { Telegram } from 'telegraf';
+import { logger } from '../../utils/logger';
+
+export class TelegramResponseService {
+  constructor(private readonly telegram: Telegram) {}
+
+  async sendAcknowledgement(
+    chatId: number,
+    text: string,
+    replyToMessageId?: number,
+  ): Promise<Message.TextMessage> {
+    return this.telegram.sendMessage(chatId, text, {
+      reply_parameters: replyToMessageId ? { message_id: replyToMessageId } : undefined,
+    });
+  }
+
+  async sendFinalResponse(chatId: number, text: string): Promise<Message.TextMessage> {
+    return this.telegram.sendMessage(chatId, text);
+  }
+
+  async sendFailureResponse(chatId: number, text: string): Promise<Message.TextMessage> {
+    return this.telegram.sendMessage(chatId, text);
+  }
+
+  async updateMessage(
+    chatId: number,
+    messageId: number,
+    text: string,
+  ): Promise<void> {
+    try {
+      await this.telegram.editMessageText(chatId, messageId, undefined, text);
+    } catch (error) {
+      logger.warn('Failed to update Telegram message', {
+        chatId,
+        messageId,
+        error: (error as Error).message,
+      });
+      throw error;
+    }
+  }
+}

--- a/src/services/telegram/telegram-update-intake.service.ts
+++ b/src/services/telegram/telegram-update-intake.service.ts
@@ -1,0 +1,98 @@
+import { Context } from 'telegraf';
+import { EnqueuedJob, InboundTask, JobType } from '../../types/job.types';
+import { JobService } from '../jobs/job.service';
+
+export class TelegramUpdateIntakeService {
+  constructor(private readonly jobService: JobService) {}
+
+  async enqueueText(ctx: Context): Promise<EnqueuedJob> {
+    if (!ctx.message || !('text' in ctx.message) || !ctx.from || !ctx.chat) {
+      throw new Error('Text message context is incomplete');
+    }
+
+    return this.jobService.enqueue(
+      this.createTask(ctx, 'text', {
+        text: ctx.message.text,
+        metadata: {
+          username: ctx.from.username,
+        },
+      }),
+    );
+  }
+
+  async enqueueVoice(ctx: Context): Promise<EnqueuedJob> {
+    if (!ctx.message || !('voice' in ctx.message) || !ctx.from || !ctx.chat) {
+      throw new Error('Voice message context is incomplete');
+    }
+
+    return this.jobService.enqueue(
+      this.createTask(ctx, 'voice', {
+        fileId: ctx.message.voice.file_id,
+        duration: ctx.message.voice.duration,
+        metadata: {
+          fileSize: ctx.message.voice.file_size,
+          username: ctx.from.username,
+        },
+      }),
+    );
+  }
+
+  async enqueueAudio(ctx: Context): Promise<EnqueuedJob> {
+    if (!ctx.message || !('audio' in ctx.message) || !ctx.from || !ctx.chat) {
+      throw new Error('Audio message context is incomplete');
+    }
+
+    return this.jobService.enqueue(
+      this.createTask(ctx, 'audio_document', {
+        fileId: ctx.message.audio.file_id,
+        fileName: ctx.message.audio.file_name || 'audio_file',
+        mimeType: ctx.message.audio.mime_type || 'application/octet-stream',
+        duration: ctx.message.audio.duration,
+        metadata: {
+          fileSize: ctx.message.audio.file_size,
+          performer: ctx.message.audio.performer,
+          title: ctx.message.audio.title,
+          username: ctx.from.username,
+        },
+      }),
+    );
+  }
+
+  async enqueueAudioDocument(ctx: Context): Promise<EnqueuedJob> {
+    if (!ctx.message || !('document' in ctx.message) || !ctx.from || !ctx.chat) {
+      throw new Error('Audio document context is incomplete');
+    }
+
+    return this.jobService.enqueue(
+      this.createTask(ctx, 'audio_document', {
+        fileId: ctx.message.document.file_id,
+        fileName: ctx.message.document.file_name || 'audio_file',
+        mimeType: ctx.message.document.mime_type || 'application/octet-stream',
+        metadata: {
+          fileSize: ctx.message.document.file_size,
+          username: ctx.from.username,
+        },
+      }),
+    );
+  }
+
+  private createTask(
+    ctx: Context,
+    kind: JobType,
+    partial: Partial<InboundTask>,
+  ): InboundTask {
+    return {
+      chatId: ctx.chat!.id,
+      userId: ctx.from!.id,
+      telegramUpdateId: ctx.update.update_id,
+      telegramMessageId: (ctx.message as { message_id: number }).message_id,
+      kind,
+      text: partial.text,
+      fileId: partial.fileId,
+      fileName: partial.fileName,
+      mimeType: partial.mimeType,
+      duration: partial.duration,
+      metadata: partial.metadata || {},
+    };
+  }
+}

--- a/src/services/tools/direct-tool-dispatcher.service.ts
+++ b/src/services/tools/direct-tool-dispatcher.service.ts
@@ -5,7 +5,13 @@
  */
 
 import { logger } from '../../utils/logger';
-import { ToolCall, ToolResult, ToolDispatcher } from '../../types/tool.types';
+import {
+  ToolCall,
+  ToolExecutionContext,
+  ToolExecutionPolicy,
+  ToolResult,
+  ToolDispatcher,
+} from '../../types/tool.types';
 import { TodoistAPIService } from '../external/todoist-api.service';
 
 /**
@@ -13,6 +19,44 @@ import { TodoistAPIService } from '../external/todoist-api.service';
  */
 export class DirectToolCallDispatcher implements ToolDispatcher {
   private readonly todoistService: TodoistAPIService;
+  private static readonly userWriteLocks = new Map<string, Promise<void>>();
+  private readonly executionPolicies: Record<string, ToolExecutionPolicy> = {
+    add_todoist_task: {
+      mutatesState: true,
+      resourceType: 'todoist_task',
+      executionMode: 'ordered_write',
+    },
+    get_todoist_task: {
+      mutatesState: false,
+      resourceType: 'todoist_task',
+      executionMode: 'parallel_read',
+    },
+    get_tasks: {
+      mutatesState: false,
+      resourceType: 'todoist_task',
+      executionMode: 'parallel_read',
+    },
+    update_todoist_task: {
+      mutatesState: true,
+      resourceType: 'todoist_task',
+      executionMode: 'ordered_write',
+    },
+    complete_task: {
+      mutatesState: true,
+      resourceType: 'todoist_task',
+      executionMode: 'ordered_write',
+    },
+    delete_todoist_task: {
+      mutatesState: true,
+      resourceType: 'todoist_task',
+      executionMode: 'ordered_write',
+    },
+    get_completed_todoist_tasks: {
+      mutatesState: false,
+      resourceType: 'todoist_task',
+      executionMode: 'parallel_read',
+    },
+  };
 
   constructor() {
     const todoistApiKey = process.env.TODOIST_API_KEY;
@@ -34,34 +78,55 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
    * @param userId - User ID for context/authorization
    * @returns Promise<ToolResult[]> - Results of all tool executions
    */
-  async executeToolCalls(toolCalls: ToolCall[], userId: string): Promise<ToolResult[]> {
+  async executeToolCalls(
+    toolCalls: ToolCall[],
+    context: ToolExecutionContext,
+  ): Promise<ToolResult[]> {
     logger.info('Executing tool calls directly', {
-      userId,
+      jobId: context.jobId,
+      userId: context.userId,
       toolCallsCount: toolCalls.length,
       functionNames: toolCalls.map((tc) => tc.function.name),
     });
 
-    // Execute all tool calls in parallel for better performance
-    const promises = toolCalls.map((toolCall) => this.executeToolCall(toolCall, userId));
+    const mustSerialize = toolCalls.some(
+      (toolCall) => this.getExecutionPolicy(toolCall.function.name)?.mutatesState,
+    );
+
+    if (mustSerialize) {
+      await context.onStage?.('tools.executing', 'Running the requested actions.');
+      const release = await this.acquireUserWriteLock(context.userId);
+      const results: ToolResult[] = [];
+      try {
+        for (const toolCall of toolCalls) {
+          try {
+            const value = await this.executeToolCall(toolCall, context);
+            results.push({
+              tool_call_id: toolCall.id,
+              content: value,
+            });
+          } catch (error) {
+            results.push({
+              tool_call_id: toolCall.id,
+              content: null,
+              error: (error as Error).message,
+            });
+          }
+        }
+      } finally {
+        release();
+      }
+      return results;
+    }
+
+    const promises = toolCalls.map((toolCall) => this.executeToolCall(toolCall, context));
     const results = await Promise.allSettled(promises);
 
-    // Convert Promise.allSettled results to our ToolResult format
-    return results.map((result, index) => {
-      const toolCallId = toolCalls[index].id;
-
-      if (result.status === 'fulfilled') {
-        return {
-          tool_call_id: toolCallId,
-          content: result.value,
-        };
-      } else {
-        return {
-          tool_call_id: toolCallId,
-          content: null,
-          error: result.reason?.message || 'Tool execution failed',
-        };
-      }
-    });
+    return results.map((result, index) => ({
+      tool_call_id: toolCalls[index].id,
+      content: result.status === 'fulfilled' ? result.value : null,
+      error: result.status === 'rejected' ? result.reason?.message || 'Tool execution failed' : undefined,
+    }));
   }
 
   /**
@@ -72,13 +137,15 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
    * @returns Promise<any> - The result of the function execution
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async executeToolCall(toolCall: ToolCall, userId: string): Promise<any> {
+  private async executeToolCall(toolCall: ToolCall, context: ToolExecutionContext): Promise<any> {
     try {
       const functionName = toolCall.function.name;
       const parameters = JSON.parse(toolCall.function.arguments);
+      const startTime = Date.now();
 
       logger.debug('Executing tool call', {
-        userId,
+        jobId: context.jobId,
+        userId: context.userId,
         functionName,
         toolCallId: toolCall.id,
         parameters: Object.keys(parameters),
@@ -87,16 +154,19 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
       const result = await this.routeFunctionCall(functionName, parameters);
 
       logger.debug('Tool call executed successfully', {
-        userId,
+        jobId: context.jobId,
+        userId: context.userId,
         functionName,
         toolCallId: toolCall.id,
         hasResult: !!result,
+        durationMs: Date.now() - startTime,
       });
 
       return result;
     } catch (error) {
       logger.error('Tool call execution error', {
-        userId,
+        jobId: context.jobId,
+        userId: context.userId,
         functionName: toolCall.function.name,
         toolCallId: toolCall.id,
         error: (error as Error).message,
@@ -203,5 +273,30 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
    */
   isFunctionSupported(functionName: string): boolean {
     return this.getSupportedFunctions().includes(functionName);
+  }
+
+  getExecutionPolicy(functionName: string): ToolExecutionPolicy | undefined {
+    return this.executionPolicies[functionName];
+  }
+
+  private async acquireUserWriteLock(userId: string): Promise<() => void> {
+    const current = DirectToolCallDispatcher.userWriteLocks.get(userId);
+    if (current) {
+      await current;
+    }
+
+    let release!: () => void;
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    DirectToolCallDispatcher.userWriteLocks.set(userId, next);
+
+    return () => {
+      if (DirectToolCallDispatcher.userWriteLocks.get(userId) === next) {
+        DirectToolCallDispatcher.userWriteLocks.delete(userId);
+      }
+      release();
+    };
   }
 }

--- a/src/types/job.types.ts
+++ b/src/types/job.types.ts
@@ -1,0 +1,114 @@
+export type JobStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'superseded';
+
+export type JobType = 'text' | 'voice' | 'audio_document';
+
+export interface InboundTask {
+  chatId: number;
+  userId: number;
+  telegramUpdateId: number;
+  telegramMessageId: number;
+  kind: JobType;
+  text?: string;
+  fileId?: string;
+  fileName?: string;
+  mimeType?: string;
+  duration?: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface MessageRecord {
+  id: number;
+  telegramUpdateId: number;
+  telegramMessageId: number;
+  chatId: number;
+  userId: number;
+  messageType: JobType;
+  payloadJson: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JobPayload {
+  text?: string;
+  fileId?: string;
+  fileName?: string;
+  mimeType?: string;
+  duration?: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface JobRecord {
+  id: string;
+  userId: number;
+  chatId: number;
+  messageId: number;
+  type: JobType;
+  status: JobStatus;
+  priority: number;
+  concurrencyKey: string | null;
+  dedupeKey: string;
+  payloadJson: string;
+  resultJson: string | null;
+  errorJson: string | null;
+  attempts: number;
+  maxAttempts: number;
+  lockedAt: string | null;
+  workerId: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  supersededByJobId: string | null;
+  ackMessageId: number | null;
+  progressMessageId: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface JobEventRecord {
+  id: number;
+  jobId: string;
+  eventType: string;
+  message: string | null;
+  payloadJson: string | null;
+  createdAt: string;
+}
+
+export interface JobExecutionResult {
+  finalMessage: string;
+  structuredResult?: Record<string, unknown>;
+  metrics?: Record<string, number>;
+  telegramDeliveryPlan?: {
+    replyToMessageId?: number;
+  };
+}
+
+export interface JobProgressReporter {
+  report(
+    eventType: string,
+    message?: string,
+    payload?: Record<string, unknown>,
+  ): Promise<void>;
+}
+
+export interface JobContext {
+  job: JobRecord;
+  payload: JobPayload;
+  progressReporter: JobProgressReporter;
+  cancellationState: {
+    isCancelled: () => Promise<boolean>;
+  };
+}
+
+export interface JobProcessor {
+  process(context: JobContext): Promise<JobExecutionResult>;
+}
+
+export interface EnqueuedJob {
+  job: JobRecord;
+  acknowledgement: string;
+}

--- a/src/types/processing.types.ts
+++ b/src/types/processing.types.ts
@@ -1,0 +1,3 @@
+export interface ProcessingHooks {
+  onStage?: (eventType: string, message?: string) => Promise<void> | void;
+}

--- a/src/types/tool.types.ts
+++ b/src/types/tool.types.ts
@@ -16,8 +16,26 @@ export interface ToolResult {
   error?: string; // Error message if execution failed
 }
 
+export type ToolExecutionMode = 'parallel_read' | 'ordered_write';
+
+export interface ToolExecutionPolicy {
+  mutatesState: boolean;
+  resourceType: string;
+  executionMode: ToolExecutionMode;
+}
+
+export interface ToolExecutionContext {
+  jobId?: string;
+  userId: string;
+  onStage?: (eventType: string, message?: string) => Promise<void> | void;
+}
+
 // Common interface for tool dispatchers
 export interface ToolDispatcher {
-  executeToolCalls(toolCalls: ToolCall[], userId: string): Promise<ToolResult[]>;
+  executeToolCalls(
+    toolCalls: ToolCall[],
+    context: ToolExecutionContext,
+  ): Promise<ToolResult[]>;
   isFunctionSupported(functionName: string): boolean;
+  getExecutionPolicy(functionName: string): ToolExecutionPolicy | undefined;
 }

--- a/tests/unit/services/jobs/job-queue.service.test.ts
+++ b/tests/unit/services/jobs/job-queue.service.test.ts
@@ -1,0 +1,43 @@
+import { JobQueueService } from '../../../../src/services/jobs/job-queue.service';
+
+describe('JobQueueService', () => {
+  it('claims the first runnable queued job', async () => {
+    const jobRepository = {
+      listQueuedJobs: jest.fn().mockResolvedValue([
+        { id: 'job-1', concurrencyKey: null },
+      ]),
+      claim: jest.fn().mockResolvedValue({ id: 'job-1', status: 'running' }),
+    } as any;
+    const scheduler = {
+      canRun: jest.fn().mockResolvedValue(true),
+    } as any;
+    const service = new JobQueueService(jobRepository, scheduler);
+
+    const job = await service.claimNextRunnableJob('worker-1');
+
+    expect(jobRepository.claim).toHaveBeenCalledWith('job-1', 'worker-1');
+    expect(job).toEqual({ id: 'job-1', status: 'running' });
+  });
+
+  it('skips queued jobs that are blocked by concurrency rules', async () => {
+    const jobRepository = {
+      listQueuedJobs: jest.fn().mockResolvedValue([
+        { id: 'job-1', concurrencyKey: 'user:1:write' },
+        { id: 'job-2', concurrencyKey: null },
+      ]),
+      claim: jest.fn().mockResolvedValue({ id: 'job-2', status: 'running' }),
+    } as any;
+    const scheduler = {
+      canRun: jest
+        .fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true),
+    } as any;
+    const service = new JobQueueService(jobRepository, scheduler);
+
+    const job = await service.claimNextRunnableJob('worker-1');
+
+    expect(jobRepository.claim).toHaveBeenCalledWith('job-2', 'worker-1');
+    expect(job).toEqual({ id: 'job-2', status: 'running' });
+  });
+});

--- a/tests/unit/services/jobs/job-scheduler.service.test.ts
+++ b/tests/unit/services/jobs/job-scheduler.service.test.ts
@@ -1,0 +1,21 @@
+import { JobSchedulerService } from '../../../../src/services/jobs/job-scheduler.service';
+
+describe('JobSchedulerService', () => {
+  it('allows jobs without a concurrency key to run', async () => {
+    const scheduler = new JobSchedulerService({} as any);
+
+    await expect(
+      scheduler.canRun({ concurrencyKey: null } as any),
+    ).resolves.toBe(true);
+  });
+
+  it('blocks jobs when the same concurrency key is already running', async () => {
+    const scheduler = new JobSchedulerService({
+      hasRunningJobForConcurrencyKey: jest.fn().mockResolvedValue(true),
+    } as any);
+
+    await expect(
+      scheduler.canRun({ concurrencyKey: 'user:1:write' } as any),
+    ).resolves.toBe(false);
+  });
+});

--- a/tests/unit/services/telegram/bot-status.service.test.ts
+++ b/tests/unit/services/telegram/bot-status.service.test.ts
@@ -18,6 +18,7 @@ describe('BotStatusService', () => {
     expect(status).toContain('HEALTHY');
     expect(status).toContain('GPT model: gpt-4o');
     expect(status).toContain('Todoist: reachable');
+    expect(status).toContain('Queued jobs: 0');
     expect(status).toContain('Total interactions: 1');
     expect(status).toContain('Last activity type: message_text');
   });

--- a/tests/unit/services/telegram/handlers/message-handlers.test.ts
+++ b/tests/unit/services/telegram/handlers/message-handlers.test.ts
@@ -4,6 +4,7 @@ describe('MessageHandlers', () => {
   function createContext(message: Record<string, unknown>) {
     return {
       from: { id: 123, username: 'tester' },
+      chat: { id: 321 },
       message,
       reply: jest.fn().mockResolvedValue(undefined),
     } as any;
@@ -12,17 +13,32 @@ describe('MessageHandlers', () => {
   it('routes audio documents through processAudioDocument', async () => {
     const fileService = {
       isAudioFile: jest.fn().mockReturnValue(true),
-      getFileUrl: jest.fn().mockResolvedValue('https://example.com/file.mp3'),
     } as any;
-    const messageProcessor = {
-      processAudioDocument: jest.fn().mockResolvedValue('processed document'),
-      processAudioMessage: jest.fn(),
+    const intakeService = {
+      enqueueAudioDocument: jest.fn().mockResolvedValue({
+        job: { id: 'job-1' },
+        acknowledgement: 'Audio file received. I’m processing it now.',
+      }),
     } as any;
     const activityService = {
       recordActivity: jest.fn(),
     } as any;
-    const handlers = new MessageHandlers(fileService, messageProcessor, activityService);
+    const responseService = {
+      sendAcknowledgement: jest.fn().mockResolvedValue({ message_id: 999 }),
+      sendFailureResponse: jest.fn(),
+    } as any;
+    const jobService = {
+      attachAcknowledgement: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const handlers = new MessageHandlers(
+      fileService,
+      intakeService,
+      activityService,
+      responseService,
+      jobService,
+    );
     const ctx = createContext({
+      message_id: 456,
       document: {
         file_id: 'file-1',
         file_name: 'meeting.mp3',
@@ -34,31 +50,37 @@ describe('MessageHandlers', () => {
     await handlers.handleDocument(ctx);
 
     expect(fileService.isAudioFile).toHaveBeenCalledWith('audio/mpeg');
-    expect(fileService.getFileUrl).toHaveBeenCalledWith('file-1');
-    expect(messageProcessor.processAudioDocument).toHaveBeenCalledWith(
-      'https://example.com/file.mp3',
-      'meeting.mp3',
-      'audio/mpeg',
-      123,
+    expect(intakeService.enqueueAudioDocument).toHaveBeenCalledWith(ctx);
+    expect(responseService.sendAcknowledgement).toHaveBeenCalledWith(
+      321,
+      'Audio file received. I’m processing it now.',
+      456,
     );
-    expect(messageProcessor.processAudioMessage).not.toHaveBeenCalled();
+    expect(jobService.attachAcknowledgement).toHaveBeenCalledWith('job-1', 999);
     expect(activityService.recordActivity).toHaveBeenCalledWith('message_document');
-    expect(ctx.reply).toHaveBeenCalledWith('processed document');
   });
 
   it('rejects non-audio documents with a helpful reply', async () => {
     const fileService = {
       isAudioFile: jest.fn().mockReturnValue(false),
-      getFileUrl: jest.fn(),
     } as any;
-    const messageProcessor = {
-      processAudioDocument: jest.fn(),
-    } as any;
+    const intakeService = {} as any;
     const activityService = {
       recordActivity: jest.fn(),
     } as any;
-    const handlers = new MessageHandlers(fileService, messageProcessor, activityService);
+    const responseService = {
+      sendFailureResponse: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const jobService = {} as any;
+    const handlers = new MessageHandlers(
+      fileService,
+      intakeService,
+      activityService,
+      responseService,
+      jobService,
+    );
     const ctx = createContext({
+      message_id: 457,
       document: {
         file_id: 'file-1',
         file_name: 'notes.pdf',
@@ -68,10 +90,9 @@ describe('MessageHandlers', () => {
 
     await handlers.handleDocument(ctx);
 
-    expect(fileService.getFileUrl).not.toHaveBeenCalled();
-    expect(messageProcessor.processAudioDocument).not.toHaveBeenCalled();
     expect(activityService.recordActivity).not.toHaveBeenCalled();
-    expect(ctx.reply).toHaveBeenCalledWith(
+    expect(responseService.sendFailureResponse).toHaveBeenCalledWith(
+      321,
       '📄 I received a document, but I only process audio files. Please send an audio file.',
     );
   });
@@ -79,16 +100,27 @@ describe('MessageHandlers', () => {
   it('falls back with a document-specific error when processing fails', async () => {
     const fileService = {
       isAudioFile: jest.fn().mockReturnValue(true),
-      getFileUrl: jest.fn().mockRejectedValue(new Error('download failed')),
     } as any;
-    const messageProcessor = {
-      processAudioDocument: jest.fn(),
+    const intakeService = {
+      enqueueAudioDocument: jest.fn().mockRejectedValue(new Error('queue failed')),
     } as any;
     const activityService = {
       recordActivity: jest.fn(),
     } as any;
-    const handlers = new MessageHandlers(fileService, messageProcessor, activityService);
+    const responseService = {
+      sendAcknowledgement: jest.fn(),
+      sendFailureResponse: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const jobService = {} as any;
+    const handlers = new MessageHandlers(
+      fileService,
+      intakeService,
+      activityService,
+      responseService,
+      jobService,
+    );
     const ctx = createContext({
+      message_id: 458,
       document: {
         file_id: 'file-1',
         file_name: 'meeting.mp3',
@@ -98,8 +130,9 @@ describe('MessageHandlers', () => {
 
     await handlers.handleDocument(ctx);
 
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '❌ Sorry, I had trouble processing your audio document.',
+    expect(responseService.sendFailureResponse).toHaveBeenCalledWith(
+      321,
+      '❌ Sorry, I had trouble queuing your audio document.',
     );
     expect(activityService.recordActivity).toHaveBeenCalledWith('message_document');
   });

--- a/tests/unit/services/telegram/handlers/telegram-handlers.test.ts
+++ b/tests/unit/services/telegram/handlers/telegram-handlers.test.ts
@@ -14,11 +14,15 @@ describe('TelegramHandlers', () => {
     const statusService = {
       getFormattedStatus: jest.fn(),
     } as any;
+    const responseService = {} as any;
+    const jobService = {} as any;
     const handlers = new TelegramHandlers(
       fileService,
       messageProcessor,
       activityService,
       statusService,
+      responseService,
+      jobService,
     );
 
     handlers.setupHandlers(bot);

--- a/tests/unit/services/telegram/telegram-bot.service.test.ts
+++ b/tests/unit/services/telegram/telegram-bot.service.test.ts
@@ -4,6 +4,7 @@ jest.mock('telegraf', () => {
       setWebhook: jest.fn().mockResolvedValue(undefined),
       deleteWebhook: jest.fn().mockResolvedValue(undefined),
       sendMessage: jest.fn().mockResolvedValue({}),
+      editMessageText: jest.fn().mockResolvedValue(undefined),
       getMe: jest.fn().mockResolvedValue({}),
       setMyCommands: jest.fn().mockResolvedValue(undefined),
     };
@@ -55,6 +56,7 @@ describe('TelegramBotService', () => {
         webhookUrl: 'https://example.com',
         secretToken: 'secret',
       },
+      {} as any,
       {} as any,
     );
   }

--- a/tests/unit/services/telegram/telegram-update-intake.service.test.ts
+++ b/tests/unit/services/telegram/telegram-update-intake.service.test.ts
@@ -1,0 +1,89 @@
+import { TelegramUpdateIntakeService } from '../../../../src/services/telegram/telegram-update-intake.service';
+
+describe('TelegramUpdateIntakeService', () => {
+  const jobService = {
+    enqueue: jest.fn().mockResolvedValue({
+      job: { id: 'job-1' },
+      acknowledgement: 'Received. Working on it.',
+    }),
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('normalizes text messages into text jobs', async () => {
+    const service = new TelegramUpdateIntakeService(jobService);
+    const ctx = {
+      update: { update_id: 10 },
+      chat: { id: 20 },
+      from: { id: 30, username: 'tester' },
+      message: { message_id: 40, text: 'hello' },
+    } as any;
+
+    await service.enqueueText(ctx);
+
+    expect(jobService.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: 20,
+        userId: 30,
+        telegramUpdateId: 10,
+        telegramMessageId: 40,
+        kind: 'text',
+        text: 'hello',
+      }),
+    );
+  });
+
+  it('normalizes voice messages into voice jobs', async () => {
+    const service = new TelegramUpdateIntakeService(jobService);
+    const ctx = {
+      update: { update_id: 11 },
+      chat: { id: 21 },
+      from: { id: 31, username: 'tester' },
+      message: {
+        message_id: 41,
+        voice: { file_id: 'voice-file', duration: 12, file_size: 999 },
+      },
+    } as any;
+
+    await service.enqueueVoice(ctx);
+
+    expect(jobService.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'voice',
+        fileId: 'voice-file',
+        duration: 12,
+      }),
+    );
+  });
+
+  it('normalizes audio documents into audio_document jobs', async () => {
+    const service = new TelegramUpdateIntakeService(jobService);
+    const ctx = {
+      update: { update_id: 12 },
+      chat: { id: 22 },
+      from: { id: 32, username: 'tester' },
+      message: {
+        message_id: 42,
+        document: {
+          file_id: 'doc-file',
+          file_name: 'memo.mp3',
+          mime_type: 'audio/mpeg',
+          file_size: 111,
+        },
+      },
+    } as any;
+
+    await service.enqueueAudioDocument(ctx);
+
+    expect(jobService.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'audio_document',
+        fileId: 'doc-file',
+        fileName: 'memo.mp3',
+        mimeType: 'audio/mpeg',
+      }),
+    );
+  });
+});

--- a/tests/unit/services/tools/direct-tool-dispatcher.service.test.ts
+++ b/tests/unit/services/tools/direct-tool-dispatcher.service.test.ts
@@ -1,0 +1,37 @@
+import { DirectToolCallDispatcher } from '../../../../src/services/tools/direct-tool-dispatcher.service';
+
+describe('DirectToolCallDispatcher', () => {
+  const originalApiKey = process.env.TODOIST_API_KEY;
+
+  beforeEach(() => {
+    process.env.TODOIST_API_KEY = 'todoist-key';
+  });
+
+  afterEach(() => {
+    if (originalApiKey === undefined) {
+      delete process.env.TODOIST_API_KEY;
+    } else {
+      process.env.TODOIST_API_KEY = originalApiKey;
+    }
+  });
+
+  it('classifies read-only tools as parallel-safe', () => {
+    const dispatcher = new DirectToolCallDispatcher();
+
+    expect(dispatcher.getExecutionPolicy('get_tasks')).toEqual({
+      mutatesState: false,
+      resourceType: 'todoist_task',
+      executionMode: 'parallel_read',
+    });
+  });
+
+  it('classifies mutating tools as ordered writes', () => {
+    const dispatcher = new DirectToolCallDispatcher();
+
+    expect(dispatcher.getExecutionPolicy('delete_todoist_task')).toEqual({
+      mutatesState: true,
+      resourceType: 'todoist_task',
+      executionMode: 'ordered_write',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implement Phase 1 async task execution for Telegram requests.

## Why
The bot was processing text, voice, Whisper, GPT, and tool execution inline on the webhook path. That blocked new messages behind long-running jobs and made write-capable tool execution unsafe to parallelize.

## Changes made
- add a SQLite-backed persistence layer for inbound messages, jobs, and job events
- enqueue Telegram text and audio requests immediately, acknowledge fast, and execute them in an in-process worker
- add worker-side text and audio job processors with progress reporting and Telegram result delivery
- classify Todoist tool calls so read-only calls can stay parallel while mutating calls run in ordered mode with per-user write locking
- extend status output and unit coverage around intake, queueing, scheduling, and tool execution policy

## Testing
- npm run build
- npm test -- --runInBand

## Notes
- this is Phase 1 infrastructure: richer progress UX, cancellation semantics, and broader integration coverage can build on top of the new job model
- the branch now tracks the HTTPS remote because SSH git transport was stalling in this environment