### PR TITLE
[Feature] merge structured observability into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Telegram → Webhook → ngrok → Your Server → Bot Service → Response → 
 # Check if your server is accessible
 curl http://localhost:3000/ping
 
+# Check Prometheus-style metrics
+curl http://localhost:3000/metrics
+
 # Check ngrok status
 curl https://your-ngrok-url.ngrok-free.app/ping
 
@@ -179,5 +182,9 @@ tail -f logs/app.log  # if you add file logging
 | `TEST_CHAT_ID` | Your Telegram user ID for testing | `987654321` |
 | `PORT` | Local server port | `3000` |
 | `NODE_ENV` | Environment mode | `development` |
+
+## Observability
+
+The app now emits structured JSON logs and exposes `/metrics` for local monitoring. See [docs/observability.md](/Users/Spare/Desktop/jarvis-mcp/docs/observability.md) for the full metric list, redaction rules, and suggested dashboard panels.
 
 Your bot is well-structured and ready to go! Just fix the environment variables and you should be able to start testing.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,78 @@
+# Observability
+
+Jarvis now exposes a local-first observability surface:
+
+- Structured JSON logs with request-scoped correlation fields
+- `/metrics` in Prometheus text format
+- Token and latency metrics for OpenAI requests
+- Whisper and tool execution timing/failure metrics
+
+## Correlation fields
+
+Every inbound webhook request creates a `requestId`. That context is threaded through the Telegram update pipeline and can include:
+
+- `requestId`
+- `updateId`
+- `chatId`
+- `userId`
+- `messageType`
+- `jobId` for future async work
+- `component`
+- `stage`
+
+## Log behavior
+
+Logs are JSON by default and redact:
+
+- `BOT_TOKEN`
+- `TELEGRAM_SECRET_TOKEN`
+- `OPENAI_API_KEY`
+- `TODOIST_API_KEY`
+- Telegram file download URLs
+
+User message bodies are not logged directly. The system records lengths, counts, IDs, and hashes instead.
+
+## Metrics
+
+Use the metrics endpoint locally:
+
+```bash
+curl http://localhost:3000/metrics
+```
+
+Primary metrics exposed:
+
+- `jarvis_webhook_requests_total`
+- `jarvis_webhook_duration_ms`
+- `jarvis_telegram_updates_total`
+- `jarvis_message_processing_duration_ms`
+- `jarvis_message_processing_failures_total`
+- `jarvis_openai_requests_total`
+- `jarvis_openai_request_duration_ms`
+- `jarvis_openai_tokens_total`
+- `jarvis_whisper_requests_total`
+- `jarvis_whisper_duration_ms`
+- `jarvis_tool_calls_total`
+- `jarvis_tool_call_duration_ms`
+- `jarvis_process_uptime_seconds`
+- `jarvis_uncaught_errors_total`
+
+## Suggested local dashboard panels
+
+- Webhook request rate and error rate
+- Webhook p50/p95 latency
+- OpenAI request latency by operation
+- OpenAI token volume over time
+- Whisper success/error count and latency
+- Tool call success/error count by tool
+- Fatal runtime error count
+
+## Useful env vars
+
+```env
+LOG_LEVEL=debug
+LOG_PRETTY=false
+METRICS_ENABLED=true
+SERVICE_NAME=jarvis-mcp
+SERVICE_VERSION=1.0.0
+```

--- a/src/app.ts
+++ b/src/app.ts
@@ -123,7 +123,7 @@ export async function initializeApplication(): Promise<AppServices> {
     new AudioJobProcessor(messageProcessor, fileService),
   );
 
-  logger.info('Services initialised', {
+  logger.info('app.services_initialized', {
     databasePath: DATABASE_PATH,
   });
 

--- a/src/controllers/webhook.controller.ts
+++ b/src/controllers/webhook.controller.ts
@@ -1,8 +1,8 @@
-// services/webhook.controller.ts
 import express from 'express';
 import type { TelegramBotService } from '../services/telegram/telegram-bot.service';
-import { logger } from '../utils/logger';
 import { ConversationStoreService, UsageTrackingService } from '../services/persistence';
+import { createTelemetryContext, recordWebhook } from '../observability';
+import { getLogger, serializeError } from '../utils/logger';
 
 export function createWebhookRouter(
   botService: TelegramBotService,
@@ -12,28 +12,46 @@ export function createWebhookRouter(
   const router = express.Router();
 
   router.post('/webhook/:secret', express.json(), async (req, res): Promise<void> => {
+    const updateId = typeof req.body?.update_id === 'number' ? req.body.update_id : undefined;
+    const from = req.body?.message?.from ?? req.body?.callback_query?.from;
+    const chat = req.body?.message?.chat ?? req.body?.callback_query?.message?.chat;
+    const context = createTelemetryContext({
+      updateId,
+      chatId: chat?.id,
+      userId: from?.id?.toString(),
+      component: 'webhook',
+      stage: 'ingress',
+    });
+    const requestLogger = getLogger(context);
+    const startTime = Date.now();
+
+    requestLogger.info('webhook.received', {
+      ip: req.ip,
+      hasUpdateBody: !!req.body,
+    });
+
     const secret = req.params.secret;
     if (!secret || secret !== process.env.TELEGRAM_SECRET_TOKEN) {
-      logger.warn('Unauthorized webhook attempt', { ip: req.ip, secret });
+      requestLogger.warn('webhook.rejected', { ip: req.ip });
+      recordWebhook('rejected', Date.now() - startTime);
       res.sendStatus(401);
       return;
     }
+
     try {
-      const updateId = typeof req.body?.update_id === 'number' ? req.body.update_id : undefined;
       if (updateId) {
         const existingMessage = await conversationStore?.findByTelegramUpdateId(updateId);
         if (existingMessage) {
-          logger.info('Skipping duplicate Telegram update', {
+          requestLogger.info('webhook.duplicate_skipped', {
             telegramUpdateId: updateId,
             messageId: existingMessage.id,
           });
+          recordWebhook('success', Date.now() - startTime);
           res.sendStatus(200);
           return;
         }
       }
 
-      const from = req.body?.message?.from ?? req.body?.callback_query?.from;
-      const chat = req.body?.message?.chat ?? req.body?.callback_query?.message?.chat;
       await usageTrackingService?.recordEvent({
         userId: from?.id?.toString(),
         chatId: chat?.id?.toString(),
@@ -44,14 +62,21 @@ export function createWebhookRouter(
         },
       });
 
-      await botService.handleUpdate(req.body);
+      await botService.handleUpdate(req.body, context);
+
+      requestLogger.info('webhook.completed', {
+        durationMs: Date.now() - startTime,
+        statusCode: 200,
+      });
+      recordWebhook('success', Date.now() - startTime);
       res.sendStatus(200);
       return;
     } catch (err) {
-      logger.error('Webhook handler failed', {
-        error: (err as Error).message,
-        stack: (err as Error).stack,
+      requestLogger.error('webhook.failed', {
+        ...serializeError(err),
+        durationMs: Date.now() - startTime,
       });
+      recordWebhook('error', Date.now() - startTime);
       res.status(500).json({ error: 'Internal Server Error' });
       return;
     }

--- a/src/observability/context.ts
+++ b/src/observability/context.ts
@@ -1,0 +1,49 @@
+import { AsyncLocalStorage } from 'async_hooks';
+import { randomUUID, createHash } from 'crypto';
+import { TelemetryContext } from './types';
+
+const telemetryStorage = new AsyncLocalStorage<TelemetryContext>();
+
+function stripUndefined<T extends object>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, fieldValue]) => fieldValue !== undefined),
+  ) as T;
+}
+
+export function createTelemetryContext(context: Partial<TelemetryContext> = {}): TelemetryContext {
+  return stripUndefined({
+    requestId: context.requestId || randomUUID(),
+    updateId: context.updateId,
+    chatId: context.chatId,
+    userId: context.userId,
+    messageType: context.messageType,
+    jobId: context.jobId,
+    component: context.component,
+    stage: context.stage,
+  });
+}
+
+export function extendTelemetryContext(
+  context: Partial<TelemetryContext> | undefined,
+  patch: Partial<TelemetryContext>,
+): TelemetryContext {
+  return createTelemetryContext({
+    ...(context || {}),
+    ...patch,
+  });
+}
+
+export function runWithTelemetryContext<T>(
+  context: TelemetryContext,
+  callback: () => T | Promise<T>,
+): T | Promise<T> {
+  return telemetryStorage.run(context, callback);
+}
+
+export function getTelemetryContext(): TelemetryContext | undefined {
+  return telemetryStorage.getStore();
+}
+
+export function hashContent(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+}

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './context';
+export * from './metrics';
+export * from './pricing';

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -1,0 +1,311 @@
+const METRICS_ENABLED = process.env.METRICS_ENABLED !== 'false';
+
+type Labels = Record<string, string>;
+
+interface MetricRecord {
+  value: number;
+  labels: Labels;
+}
+
+interface HistogramRecord {
+  sum: number;
+  count: number;
+  buckets: Map<number, number>;
+  labels: Labels;
+}
+
+const metricHelp = new Map<string, string>();
+const counters = new Map<string, Map<string, MetricRecord>>();
+const gauges = new Map<string, Map<string, MetricRecord>>();
+const histograms = new Map<string, Map<string, HistogramRecord>>();
+
+const webhookBuckets = [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
+const messageBuckets = [25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000];
+const openAIBuckets = [50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000];
+const toolBuckets = [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
+
+function isEnabled(): boolean {
+  return METRICS_ENABLED;
+}
+
+function ensureHelp(name: string, help: string): void {
+  if (!metricHelp.has(name)) {
+    metricHelp.set(name, help);
+  }
+}
+
+function serializeLabels(labels: Labels): string {
+  return Object.entries(labels)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('|');
+}
+
+function formatLabels(labels: Labels): string {
+  const entries = Object.entries(labels).sort(([left], [right]) => left.localeCompare(right));
+  if (entries.length === 0) {
+    return '';
+  }
+
+  return `{${entries
+    .map(([key, value]) => `${key}="${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`)
+    .join(',')}}`;
+}
+
+function incrementCounter(name: string, help: string, labels: Labels, value = 1): void {
+  ensureHelp(name, help);
+  const bucket = counters.get(name) || new Map<string, MetricRecord>();
+  const key = serializeLabels(labels);
+  const current = bucket.get(key) || { value: 0, labels };
+  current.value += value;
+  bucket.set(key, current);
+  counters.set(name, bucket);
+}
+
+function setGauge(name: string, help: string, labels: Labels, value: number): void {
+  ensureHelp(name, help);
+  const bucket = gauges.get(name) || new Map<string, MetricRecord>();
+  bucket.set(serializeLabels(labels), { value, labels });
+  gauges.set(name, bucket);
+}
+
+function observeHistogram(
+  name: string,
+  help: string,
+  labels: Labels,
+  value: number,
+  buckets: number[],
+): void {
+  ensureHelp(name, help);
+  const histogram = histograms.get(name) || new Map<string, HistogramRecord>();
+  const key = serializeLabels(labels);
+  const current =
+    histogram.get(key) ||
+    ({
+      sum: 0,
+      count: 0,
+      buckets: new Map<number, number>(buckets.map((bucket) => [bucket, 0])),
+      labels,
+    } satisfies HistogramRecord);
+
+  current.sum += value;
+  current.count += 1;
+  for (const bucket of buckets) {
+    if (value <= bucket) {
+      current.buckets.set(bucket, (current.buckets.get(bucket) || 0) + 1);
+    }
+  }
+
+  histogram.set(key, current);
+  histograms.set(name, histogram);
+}
+
+type OpenAIUsage = {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+};
+
+export function recordWebhook(status: 'success' | 'rejected' | 'error', durationMs: number): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_webhook_requests_total',
+    'Total webhook requests by status',
+    { status },
+  );
+  observeHistogram(
+    'jarvis_webhook_duration_ms',
+    'Webhook request duration in milliseconds',
+    {},
+    durationMs,
+    webhookBuckets,
+  );
+}
+
+export function recordTelegramUpdate(type: string): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_telegram_updates_total',
+    'Telegram updates processed by type',
+    { type: type || 'unknown' },
+  );
+}
+
+export function recordMessageProcessingDuration(messageType: string, durationMs: number): void {
+  if (!isEnabled()) return;
+  observeHistogram(
+    'jarvis_message_processing_duration_ms',
+    'Message processing duration by message type',
+    { message_type: messageType || 'unknown' },
+    durationMs,
+    messageBuckets,
+  );
+}
+
+export function recordMessageProcessingFailure(messageType: string, stage: string): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_message_processing_failures_total',
+    'Message processing failures by message type and stage',
+    { message_type: messageType || 'unknown', stage: stage || 'unknown' },
+  );
+}
+
+export function recordOpenAIRequest(
+  labels: { model: string; operation: string; status: string },
+  durationMs: number,
+  usage?: OpenAIUsage,
+): void {
+  if (!isEnabled()) return;
+
+  const safeLabels = {
+    model: labels.model || 'unknown',
+    operation: labels.operation || 'unknown',
+    status: labels.status || 'unknown',
+  };
+
+  incrementCounter(
+    'jarvis_openai_requests_total',
+    'OpenAI requests by model, operation, and status',
+    safeLabels,
+  );
+  observeHistogram(
+    'jarvis_openai_request_duration_ms',
+    'OpenAI request duration by model and operation',
+    { model: safeLabels.model, operation: safeLabels.operation },
+    durationMs,
+    openAIBuckets,
+  );
+
+  if (usage?.promptTokens !== undefined) {
+    incrementCounter(
+      'jarvis_openai_tokens_total',
+      'OpenAI token usage by model and direction',
+      { model: safeLabels.model, direction: 'prompt' },
+      usage.promptTokens,
+    );
+  }
+  if (usage?.completionTokens !== undefined) {
+    incrementCounter(
+      'jarvis_openai_tokens_total',
+      'OpenAI token usage by model and direction',
+      { model: safeLabels.model, direction: 'completion' },
+      usage.completionTokens,
+    );
+  }
+  if (usage?.totalTokens !== undefined) {
+    incrementCounter(
+      'jarvis_openai_tokens_total',
+      'OpenAI token usage by model and direction',
+      { model: safeLabels.model, direction: 'total' },
+      usage.totalTokens,
+    );
+  }
+}
+
+export function recordWhisperRequest(status: 'success' | 'error', durationMs: number): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_whisper_requests_total',
+    'Whisper requests by status',
+    { status },
+  );
+  observeHistogram(
+    'jarvis_whisper_duration_ms',
+    'Whisper processing duration in milliseconds',
+    {},
+    durationMs,
+    openAIBuckets,
+  );
+}
+
+export function recordToolCall(tool: string, status: 'success' | 'error', durationMs: number): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_tool_calls_total',
+    'Tool calls by tool name and status',
+    { tool: tool || 'unknown', status },
+  );
+  observeHistogram(
+    'jarvis_tool_call_duration_ms',
+    'Tool call duration by tool name',
+    { tool: tool || 'unknown' },
+    durationMs,
+    toolBuckets,
+  );
+}
+
+export function recordUncaughtError(kind: string): void {
+  if (!isEnabled()) return;
+  incrementCounter(
+    'jarvis_uncaught_errors_total',
+    'Uncaught process errors by kind',
+    { kind: kind || 'unknown' },
+  );
+}
+
+function renderCounter(name: string, values: Map<string, MetricRecord>): string[] {
+  return Array.from(values.values()).map(
+    (record) => `${name}${formatLabels(record.labels)} ${record.value}`,
+  );
+}
+
+function renderGauge(name: string, values: Map<string, MetricRecord>): string[] {
+  return Array.from(values.values()).map(
+    (record) => `${name}${formatLabels(record.labels)} ${record.value}`,
+  );
+}
+
+function renderHistogram(name: string, values: Map<string, HistogramRecord>): string[] {
+  const lines: string[] = [];
+
+  for (const value of values.values()) {
+    const sortedBuckets = Array.from(value.buckets.entries()).sort(([left], [right]) => left - right);
+    for (const [bucket, count] of sortedBuckets) {
+      lines.push(`${name}_bucket${formatLabels({ ...value.labels, le: String(bucket) })} ${count}`);
+    }
+    lines.push(`${name}_bucket${formatLabels({ ...value.labels, le: '+Inf' })} ${value.count}`);
+    lines.push(`${name}_sum${formatLabels(value.labels)} ${value.sum}`);
+    lines.push(`${name}_count${formatLabels(value.labels)} ${value.count}`);
+  }
+
+  return lines;
+}
+
+export async function getMetricsSnapshot(): Promise<string> {
+  if (!isEnabled()) {
+    return '';
+  }
+
+  setGauge('jarvis_process_uptime_seconds', 'Current process uptime in seconds', {}, process.uptime());
+
+  const lines: string[] = [];
+  for (const [name, help] of metricHelp.entries()) {
+    lines.push(`# HELP ${name} ${help}`);
+    const type = counters.has(name) ? 'counter' : gauges.has(name) ? 'gauge' : 'histogram';
+    lines.push(`# TYPE ${name} ${type}`);
+
+    if (counters.has(name)) {
+      lines.push(...renderCounter(name, counters.get(name)!));
+    } else if (gauges.has(name)) {
+      lines.push(...renderGauge(name, gauges.get(name)!));
+    } else if (histograms.has(name)) {
+      lines.push(...renderHistogram(name, histograms.get(name)!));
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function getMetricsContentType(): string {
+  return 'text/plain; version=0.0.4; charset=utf-8';
+}
+
+export function resetMetrics(): void {
+  counters.clear();
+  gauges.clear();
+  histograms.clear();
+  metricHelp.clear();
+}
+
+export { METRICS_ENABLED };

--- a/src/observability/pricing.ts
+++ b/src/observability/pricing.ts
@@ -1,0 +1,29 @@
+const OPENAI_PRICING_USD_PER_1K_TOKENS: Record<string, { input: number; output: number }> = {
+  'gpt-4o': { input: 0.005, output: 0.015 },
+  'gpt-4o-mini': { input: 0.00015, output: 0.0006 },
+  'gpt-4o-transcribe': { input: 0.006, output: 0 },
+};
+
+export interface CostEstimateInput {
+  model: string;
+  promptTokens?: number;
+  completionTokens?: number;
+}
+
+export function estimateOpenAICostUsd({
+  model,
+  promptTokens = 0,
+  completionTokens = 0,
+}: CostEstimateInput): number | undefined {
+  const pricing = OPENAI_PRICING_USD_PER_1K_TOKENS[model];
+  if (!pricing) {
+    return undefined;
+  }
+
+  return Number(
+    (
+      (promptTokens / 1000) * pricing.input +
+      (completionTokens / 1000) * pricing.output
+    ).toFixed(6),
+  );
+}

--- a/src/observability/types.ts
+++ b/src/observability/types.ts
@@ -1,0 +1,18 @@
+export type MessageType = 'text' | 'audio' | 'audio_document' | 'command' | 'unknown';
+
+export type PrimitiveLogValue = string | number | boolean | null | undefined;
+
+export type LogFields = Record<string, PrimitiveLogValue | PrimitiveLogValue[]>;
+
+export type MetricTags = Record<string, string>;
+
+export interface TelemetryContext {
+  requestId: string;
+  updateId?: number;
+  chatId?: string | number;
+  userId?: string;
+  messageType?: MessageType;
+  jobId?: string;
+  component?: string;
+  stage?: string;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,10 @@
 import express, { Request, Response, NextFunction } from 'express';
-import { logger } from './utils/logger';
+import {
+  getMetricsContentType,
+  getMetricsSnapshot,
+  recordUncaughtError,
+} from './observability';
+import { logger, serializeError } from './utils/logger';
 import { createWebhookRouter } from './controllers/webhook.controller';
 import { initializeApplication } from './app';
 
@@ -12,9 +17,7 @@ async function startServer(): Promise<void> {
   try {
     await services.botService.setupWebhook(NGROK_URL, TELEGRAM_SECRET_TOKEN);
   } catch (err) {
-    logger.error('Error setting up webhook', {
-      error: (err as Error).message,
-    });
+    logger.error('app.webhook_setup_failed', serializeError(err));
   }
 
   const app = express();
@@ -22,6 +25,11 @@ async function startServer(): Promise<void> {
 
   app.get('/ping', (_req: Request, res: Response, _next: NextFunction) => {
     res.json({ status: 'ok' });
+  });
+
+  app.get('/metrics', async (_req: Request, res: Response) => {
+    res.setHeader('Content-Type', getMetricsContentType());
+    res.send(await getMetricsSnapshot());
   });
 
   app.use(
@@ -35,23 +43,44 @@ async function startServer(): Promise<void> {
   services.workerService.start();
 
   const PORT = process.env.PORT || 3000;
+  logger.info('app.starting', { port: PORT });
   app.listen(PORT, () => {
-    logger.info(`Server started at http://localhost:${PORT}`);
-    logger.info(`Waiting for Telegram updates on /webhook/:secret`);
+    logger.info('app.ready', {
+      port: PORT,
+      healthPath: '/ping',
+      metricsPath: '/metrics',
+    });
   });
 
-  const shutdown = async () => {
-    logger.info('Shutting down gracefully...');
+  const shutdown = async (signal: string) => {
+    logger.info('app.shutting_down', { signal });
     await services.workerService.stop();
     await services.databaseService.close();
     process.exit(0);
   };
 
   process.on('SIGTERM', () => {
-    void shutdown();
+    void shutdown('SIGTERM');
   });
   process.on('SIGINT', () => {
-    void shutdown();
+    void shutdown('SIGINT');
+  });
+
+  process.on('uncaughtException', (error) => {
+    recordUncaughtError('uncaughtException');
+    logger.error('runtime.fatal', {
+      kind: 'uncaughtException',
+      ...serializeError(error),
+    });
+    process.exit(1);
+  });
+
+  process.on('unhandledRejection', (reason) => {
+    recordUncaughtError('unhandledRejection');
+    logger.error('runtime.fatal', {
+      kind: 'unhandledRejection',
+      ...serializeError(reason),
+    });
   });
 }
 

--- a/src/services/ai/gpt.service.ts
+++ b/src/services/ai/gpt.service.ts
@@ -1,6 +1,11 @@
 import OpenAI from 'openai';
-import { logger } from '../../utils/logger';
 import { ToolDispatcher } from '../../types/tool.types';
+import {
+  estimateOpenAICostUsd,
+  extendTelemetryContext,
+  recordOpenAIRequest,
+} from '../../observability';
+import { getLogger, serializeError } from '../../utils/logger';
 import { GPT_CONSTANTS } from './constants/gpt.constants';
 import { GPTConfig, InternalGPTConfig, MessageProcessingResult } from '../../types/gpt.types';
 import { GPTValidator } from './validators/gpt.validator';
@@ -44,7 +49,7 @@ export class GPTService {
     );
     this.simpleTextProcessor = new SimpleTextProcessor();
 
-    logger.info('GPTService initialized', {
+    getLogger({ requestId: 'startup', component: 'gpt_service' }).info('openai.service.initialized', {
       model: this.config.model,
       maxInputLength: this.config.maxInputLength,
       temperature: this.config.temperature,
@@ -64,12 +69,21 @@ export class GPTService {
     context?: GPTProcessingContext,
   ): Promise<MessageProcessingResult> {
     const startTime = Date.now();
-
-    logger.info('Processing message with GPT', {
-      jobId: context?.jobId,
+    const scopedContext = extendTelemetryContext(context, {
+      requestId: context?.requestId || context?.jobId,
+      component: 'gpt_service',
       userId,
+      chatId: context?.chatId,
+      jobId: context?.jobId,
+      stage: 'openai_chat',
+    });
+    const logger = getLogger(scopedContext);
+
+    logger.info('openai.chat.requested', {
       messageLength: message.length,
       functionCallingEnabled: this.enableFunctionCalling,
+      operation: this.enableFunctionCalling ? 'function_calling' : 'simple_text',
+      model: this.config.model,
     });
 
     const MAX_RETRIES = 3;
@@ -93,8 +107,10 @@ export class GPTService {
         });
 
         let result: MessageProcessingResult;
+        let operation: 'function_calling' | 'simple_text';
 
         if (this.enableFunctionCalling) {
+          operation = 'function_calling';
           result = await this.functionCallingProcessor.processWithFunctionCalling(
             this.openai,
             this.config.model,
@@ -104,14 +120,32 @@ export class GPTService {
             context,
           );
         } else {
+          operation = 'simple_text';
           result = await this.simpleTextProcessor.processSimpleMessage(
             this.openai,
             this.config.model,
             this.config.temperature,
             message,
             userId,
+            context,
           );
         }
+
+        result.usage = result.usage || {
+          promptTokens: result.inputTokens,
+          completionTokens: result.outputTokens,
+          totalTokens: result.totalTokens,
+        };
+        result.inputTokens = result.inputTokens ?? result.usage?.promptTokens;
+        result.outputTokens = result.outputTokens ?? result.usage?.completionTokens;
+        result.totalTokens = result.totalTokens ?? result.usage?.totalTokens;
+        result.estimatedCostUsd =
+          result.estimatedCostUsd ??
+          estimateOpenAICostUsd({
+            model: result.model,
+            promptTokens: result.inputTokens,
+            completionTokens: result.outputTokens,
+          });
 
         await this.usageTrackingService?.recordEvent({
           userId,
@@ -130,18 +164,31 @@ export class GPTService {
           },
         });
 
+        recordOpenAIRequest(
+          { model: result.model, operation, status: 'success' },
+          result.processingTimeMs,
+          result.usage,
+        );
+        logger.info('openai.chat.succeeded', {
+          model: result.model,
+          durationMs: result.processingTimeMs,
+          operation,
+          promptTokens: result.inputTokens,
+          completionTokens: result.outputTokens,
+          totalTokens: result.totalTokens,
+          estimatedCostUsd: result.estimatedCostUsd,
+        });
+
         return result;
       } catch (error) {
         lastError = error as Error;
 
         if (attempt < MAX_RETRIES && GPTErrorHandler.isRetryableError(lastError)) {
           const delay = GPTErrorHandler.getRetryDelay(attempt);
-          logger.warn('Retryable error encountered, retrying', {
-            jobId: context?.jobId,
-            userId,
+          logger.warn('openai.chat.retry_scheduled', {
             attempt,
             delayMs: delay,
-            error: lastError.message,
+            ...serializeError(lastError),
           });
           await new Promise((resolve) => setTimeout(resolve, delay));
           continue;
@@ -153,13 +200,20 @@ export class GPTService {
 
     const processingTimeMs = Date.now() - startTime;
 
-    logger.error('Message processing failed', {
-      jobId: context?.jobId,
-      userId,
+    logger.error('openai.chat.failed', {
       messageLength: message.length,
-      error: lastError!.message,
       processingTimeMs,
+      model: this.config.model,
+      ...serializeError(lastError),
     });
+    recordOpenAIRequest(
+      {
+        model: this.config.model,
+        operation: this.enableFunctionCalling ? 'function_calling' : 'simple_text',
+        status: 'error',
+      },
+      processingTimeMs,
+    );
 
     await this.usageTrackingService?.recordEvent({
       userId,

--- a/src/services/ai/processors/function-calling.processor.ts
+++ b/src/services/ai/processors/function-calling.processor.ts
@@ -1,5 +1,6 @@
 import OpenAI from 'openai';
-import { logger } from '../../../utils/logger';
+import { extendTelemetryContext } from '../../../observability';
+import { getLogger, serializeError } from '../../../utils/logger';
 import { MessageProcessingResult } from '../../../types/gpt.types';
 import { GPT_CONSTANTS } from '../constants/gpt.constants';
 import { getFunctionCallingSystemPrompt, FINAL_RESPONSE_PROMPT } from '../../../types/gpt.prompts';
@@ -27,6 +28,15 @@ export class FunctionCallingProcessor {
     context?: GPTProcessingContext,
   ): Promise<MessageProcessingResult> {
     const startTime = Date.now();
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        requestId: context?.requestId || context?.jobId,
+        component: 'function_calling_processor',
+        userId,
+        chatId: context?.chatId,
+        jobId: context?.jobId,
+      }),
+    );
 
     try {
       const response = await openai.chat.completions.create({
@@ -48,15 +58,16 @@ export class FunctionCallingProcessor {
       });
 
       const responseMessage = response.choices[0].message;
-      const initialInputTokens = response.usage?.prompt_tokens || 0;
-      const initialOutputTokens = response.usage?.completion_tokens || 0;
+      const usage = {
+        promptTokens: response.usage?.prompt_tokens,
+        completionTokens: response.usage?.completion_tokens,
+        totalTokens: response.usage?.total_tokens,
+      };
 
-      logger.debug('GPT function calling response', {
-        jobId: context?.jobId,
-        userId,
+      logger.debug('openai.chat.succeeded', {
         hasToolCalls: !!(responseMessage.tool_calls && responseMessage.tool_calls.length > 0),
         toolCallsCount: responseMessage.tool_calls?.length || 0,
-        content: responseMessage.content,
+        hasContent: !!responseMessage.content,
       });
 
       if (responseMessage.tool_calls && responseMessage.tool_calls.length > 0) {
@@ -77,9 +88,10 @@ export class FunctionCallingProcessor {
           usedFunctionCalling: true,
           functionCallsCount: responseMessage.tool_calls.length,
           model,
-          inputTokens: initialInputTokens,
-          outputTokens: initialOutputTokens,
-          totalTokens: response.usage?.total_tokens,
+          usage,
+          inputTokens: usage.promptTokens,
+          outputTokens: usage.completionTokens,
+          totalTokens: usage.totalTokens,
         };
       }
 
@@ -91,17 +103,13 @@ export class FunctionCallingProcessor {
         usedFunctionCalling: false,
         functionCallsCount: 0,
         model,
-        inputTokens: initialInputTokens,
-        outputTokens: initialOutputTokens,
-        totalTokens: response.usage?.total_tokens,
+        usage,
+        inputTokens: usage.promptTokens,
+        outputTokens: usage.completionTokens,
+        totalTokens: usage.totalTokens,
       };
     } catch (error) {
-      logger.error('Function calling processing failed', {
-        jobId: context?.jobId,
-        userId,
-        error: (error as Error).message,
-      });
-
+      logger.error('openai.chat.failed', serializeError(error));
       throw error;
     }
   }
@@ -115,6 +123,16 @@ export class FunctionCallingProcessor {
     userId: string,
     context?: GPTProcessingContext,
   ): Promise<string> {
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        requestId: context?.requestId || context?.jobId,
+        component: 'tool_dispatch',
+        userId,
+        chatId: context?.chatId,
+        jobId: context?.jobId,
+        stage: 'dispatch',
+      }),
+    );
     if (!this.toolDispatcher || !responseMessage.tool_calls) {
       return "I'd like to help you with that, but I'm currently unable to execute the required actions.";
     }
@@ -129,9 +147,7 @@ export class FunctionCallingProcessor {
         },
       }));
 
-      logger.info('Executing tool calls', {
-        jobId: context?.jobId,
-        userId,
+      logger.info('tool.dispatch.started', {
         toolCalls: toolCalls.map((tc) => ({
           id: tc.id,
           name: tc.function.name,
@@ -156,7 +172,7 @@ export class FunctionCallingProcessor {
         if (this.toolDispatcher!.isFunctionSupported(tc.function.name)) {
           return true;
         }
-        logger.warn('Skipping unsupported function', { name: tc.function.name, userId });
+        logger.warn('tool.call.failed', { name: tc.function.name, reason: 'unsupported_function' });
         return false;
       });
 
@@ -166,14 +182,15 @@ export class FunctionCallingProcessor {
 
       await context?.onStage?.('tools.executing');
       const toolResults = await this.toolDispatcher.executeToolCalls(supportedCalls, {
+        requestId: context?.requestId || context?.jobId,
         userId,
+        chatId: context?.chatId,
         jobId: context?.jobId,
+        messageType: context?.messageType,
         onStage: context?.onStage,
       });
 
-      logger.info('Tool execution completed', {
-        jobId: context?.jobId,
-        userId,
+      logger.info('tool.dispatch.completed', {
         results: toolResults.map((result) => ({
           tool_call_id: result.tool_call_id,
           success: !result.error,
@@ -205,12 +222,7 @@ export class FunctionCallingProcessor {
         toolResults,
       );
     } catch (error) {
-      logger.error('Tool call execution failed', {
-        jobId: context?.jobId,
-        userId,
-        error: (error as Error).message,
-      });
-
+      logger.error('tool.dispatch.failed', serializeError(error));
       return `I encountered an error while trying to help you: ${(error as Error).message}. Please try again or rephrase your request.`;
     }
   }
@@ -260,9 +272,10 @@ export class FunctionCallingProcessor {
         'I completed the requested actions successfully.'
       );
     } catch (error) {
-      logger.error('Failed to generate final response', {
-        error: (error as Error).message,
-      });
+      getLogger({ requestId: 'tool-response', component: 'tool_dispatch' }).error(
+        'openai.chat.failed',
+        serializeError(error),
+      );
 
       const successfulActions = toolResults.filter((result) => !result.error);
       if (successfulActions.length > 0) {

--- a/src/services/ai/processors/simple-text.processor.ts
+++ b/src/services/ai/processors/simple-text.processor.ts
@@ -1,37 +1,30 @@
-/**
- * Simple text processor for GPT service
- *
- * @module SimpleTextProcessor
- */
-
 import OpenAI from 'openai';
-import { logger } from '../../../utils/logger';
+import { extendTelemetryContext } from '../../../observability';
+import { getLogger, serializeError } from '../../../utils/logger';
 import { GPT_CONSTANTS } from '../constants/gpt.constants';
 import { SIMPLE_CONVERSATION_PROMPT } from '../../../types/gpt.prompts';
 import { MessageProcessingResult } from '../../../types/gpt.types';
+import { ProcessingContext } from '../../../types/processing.types';
 
-/**
- * Processor for handling simple text generation without function calling
- */
 export class SimpleTextProcessor {
-  /**
-   * Process message with simple text generation (no function calling)
-   *
-   * @param openai - OpenAI client instance
-   * @param model - Model to use for processing
-   * @param temperature - Temperature setting for the model
-   * @param message - User message
-   * @param userId - User ID (optional)
-   * @returns Promise<string> - Generated response
-   */
   async processSimpleMessage(
     openai: OpenAI,
     model: string,
     temperature: number,
     message: string,
     userId?: string,
+    context?: ProcessingContext,
   ): Promise<MessageProcessingResult> {
     const startTime = Date.now();
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        requestId: context?.requestId || context?.jobId,
+        component: 'simple_text_processor',
+        userId,
+        chatId: context?.chatId,
+        jobId: context?.jobId,
+      }),
+    );
 
     try {
       const completion = await openai.chat.completions.create({
@@ -59,16 +52,17 @@ export class SimpleTextProcessor {
         usedFunctionCalling: false,
         functionCallsCount: 0,
         model,
+        usage: {
+          promptTokens: completion.usage?.prompt_tokens,
+          completionTokens: completion.usage?.completion_tokens,
+          totalTokens: completion.usage?.total_tokens,
+        },
         inputTokens: completion.usage?.prompt_tokens,
         outputTokens: completion.usage?.completion_tokens,
         totalTokens: completion.usage?.total_tokens,
       };
     } catch (error) {
-      logger.error('Simple message processing failed', {
-        userId,
-        error: (error as Error).message,
-      });
-
+      logger.error('openai.chat.failed', serializeError(error));
       throw error;
     }
   }

--- a/src/services/ai/whisper.service.ts
+++ b/src/services/ai/whisper.service.ts
@@ -1,86 +1,47 @@
-// src/services/ai/whisper.service.ts
-
-/**
- * Service for transcribing audio files using OpenAI Whisper API.
- * Handles audio file downloads, validation, and transcription processing.
- *
- * @example
- * ```typescript
- * const whisperService = new WhisperService();
- * const transcription = await whisperService.transcribeAudio('https://example.com/audio.ogg');
- * ```
- */
-
 import OpenAI from 'openai';
-import { logger } from '../../utils/logger';
+import {
+  extendTelemetryContext,
+  hashContent,
+  recordWhisperRequest,
+} from '../../observability';
+import { getLogger, serializeError } from '../../utils/logger';
 import { AudioMimeTypes } from '../../utils/constants';
 import { validateFileSize } from '../../utils/ai/fileValidation';
 import { AudioConverter } from '../../utils/ai/audioConverter';
 import { UsageTrackingService } from '../persistence';
 import { ProcessingContext } from '../../types/processing.types';
 
-/**
- * Constants for Whisper service configuration
- */
 const WHISPER_CONSTANTS = {
-  /** Default maximum file size (25MB as per OpenAI limits) */
   DEFAULT_MAX_FILE_SIZE_BYTES: 25 * 1024 * 1024,
-  /** Default Whisper model */
   DEFAULT_MODEL: 'gpt-4o-transcribe',
-  /** Default response format */
   DEFAULT_RESPONSE_FORMAT: 'text' as const,
-  /** Default language (English) */
   DEFAULT_LANGUAGE: 'en',
-  /** Maximum text length to log for privacy */
   MAX_LOG_TEXT_LENGTH: 100,
 } as const;
 
-/**
- * Configuration interface for Whisper service options
- */
 interface WhisperConfig {
-  /** OpenAI API key - loaded from environment variables */
   apiKey: string;
-  /** Maximum file size in bytes (default: 25MB as per OpenAI limits) */
   maxFileSizeBytes?: number;
-  /** Model to use for transcription (default: whisper-1) */
   model?: string;
-  /** Language for transcription (default: 'en' for English only) */
   language?: string;
-  /** Response format (default: text) */
   responseFormat?: 'json' | 'text' | 'srt' | 'verbose_json' | 'vtt';
-  /** Whether to enforce English-only transcription (default: true) */
   enforceEnglishOnly?: boolean;
 }
 
-/**
- * Result interface for transcription operations
- */
 interface TranscriptionResult {
-  /** The transcribed text */
   text: string;
-  /** Original file URL */
   fileUrl: string;
   processingTimeMs: number;
   detectedLanguage?: string;
   fileSizeBytes: number;
 }
 
-/**
- * Service for transcribing audio files using OpenAI Whisper API
- */
 export class WhisperService {
   private readonly openai: OpenAI;
   private readonly config: Required<Omit<WhisperConfig, 'language'>>;
   private readonly language: string;
   private readonly usageTrackingService?: UsageTrackingService;
 
-  /**
-   * Creates a new WhisperService instance
-   *
-   * @param config - Configuration options for the service
-   * @throws {Error} If OpenAI API key is not provided
-   */
   constructor(config?: Partial<WhisperConfig>, usageTrackingService?: UsageTrackingService) {
     const apiKey = config?.apiKey || process.env.OPENAI_API_KEY;
 
@@ -93,10 +54,7 @@ export class WhisperService {
     this.openai = new OpenAI({ apiKey });
     this.usageTrackingService = usageTrackingService;
 
-    // Set default configuration with provided overrides
-    // Always enforce English-only transcription unless explicitly disabled
     const enforceEnglishOnly = config?.enforceEnglishOnly !== false;
-
     this.config = {
       apiKey,
       maxFileSizeBytes: config?.maxFileSizeBytes || WHISPER_CONSTANTS.DEFAULT_MAX_FILE_SIZE_BYTES,
@@ -105,12 +63,11 @@ export class WhisperService {
       enforceEnglishOnly,
     };
 
-    // Set language to English when enforcing English-only, otherwise use provided language
     this.language = enforceEnglishOnly
       ? WHISPER_CONSTANTS.DEFAULT_LANGUAGE
       : config?.language || WHISPER_CONSTANTS.DEFAULT_LANGUAGE;
 
-    logger.info('WhisperService initialized', {
+    getLogger({ requestId: 'startup', component: 'whisper_service' }).info('audio.service.initialized', {
       model: this.config.model,
       maxFileSizeMB: Math.round(this.config.maxFileSizeBytes / (1024 * 1024)),
       responseFormat: this.config.responseFormat,
@@ -119,44 +76,37 @@ export class WhisperService {
     });
   }
 
-  /**
-   * Transcribes audio from a given URL
-   *
-   * @param fileUrl - URL of the audio file to transcribe
-   * @param userId - Optional user ID for logging purposes
-   * @returns Promise resolving to transcription result
-   * @throws {Error} If file download fails, file is too large, or transcription fails
-   */
   async transcribeAudio(
     fileUrl: string,
     userId?: number,
     context?: ProcessingContext,
   ): Promise<TranscriptionResult> {
     const startTime = Date.now();
+    const scopedContext = extendTelemetryContext(context, {
+      requestId: context?.requestId || context?.jobId,
+      component: 'whisper_service',
+      userId: userId ? String(userId) : context?.userId,
+      chatId: context?.chatId,
+      jobId: context?.jobId,
+      stage: 'transcription',
+    });
+    const logger = getLogger(scopedContext);
 
-    logger.info('Starting audio transcription', {
-      userId,
-      fileUrl: this.sanitizeUrlForLogging(fileUrl),
+    logger.info('audio.transcription.started', {
+      fileUrlHash: hashContent(fileUrl),
     });
 
     try {
-      // Download the audio file
-      const audioBuffer = await this.downloadAudioFile(fileUrl);
-
-      // Validate file size
+      const audioBuffer = await this.downloadAudioFile(fileUrl, context);
       validateFileSize(audioBuffer.length, this.config.maxFileSizeBytes);
 
-      // Determine file extension from URL or default to supported format
       const originalExtension = this.extractFileExtension(fileUrl) || 'ogg';
-
-      // Check if the audio format needs conversion
       let processedBuffer = audioBuffer;
       let fileExtension = originalExtension;
       let conversionTimeMs = 0;
 
       if (AudioConverter.needsConversion(originalExtension)) {
-        logger.info('Audio format needs conversion', {
-          userId,
+        logger.info('audio.conversion.started', {
           originalFormat: originalExtension,
           targetFormat: AudioConverter.getTargetFormat(),
         });
@@ -166,17 +116,16 @@ export class WhisperService {
             audioBuffer,
             originalExtension,
             userId,
+            scopedContext,
           );
 
           processedBuffer = conversionResult.convertedBuffer;
           fileExtension = conversionResult.targetFormat;
           conversionTimeMs = conversionResult.conversionTimeMs;
 
-          // Validate converted file size
           validateFileSize(processedBuffer.length, this.config.maxFileSizeBytes);
 
-          logger.info('Audio conversion completed', {
-            userId,
+          logger.info('audio.conversion.succeeded', {
             originalFormat: originalExtension,
             targetFormat: fileExtension,
             originalSize: audioBuffer.length,
@@ -184,13 +133,11 @@ export class WhisperService {
             conversionTimeMs,
           });
         } catch (conversionError) {
-          logger.error('Audio conversion failed', {
-            userId,
+          logger.error('audio.conversion.failed', {
             originalFormat: originalExtension,
-            error: (conversionError as Error).message,
+            ...serializeError(conversionError),
           });
 
-          // Provide helpful error message for conversion failures
           const errorMessage = (conversionError as Error).message;
           if (errorMessage.includes('FFmpeg is not available')) {
             throw new Error(
@@ -203,14 +150,11 @@ export class WhisperService {
         }
       }
 
-      // Create a File object for the OpenAI API
       const audioFile = new File([new Uint8Array(processedBuffer)], `audio.${fileExtension}`, {
         type: this.getMimeTypeFromExtension(fileExtension),
       });
 
-      // Perform transcription
-      const transcription = await this.performTranscription(audioFile);
-
+      const transcription = await this.performTranscription(audioFile, context);
       const processingTimeMs = Date.now() - startTime;
 
       const result: TranscriptionResult = {
@@ -220,10 +164,8 @@ export class WhisperService {
         fileSizeBytes: processedBuffer.length,
       };
 
-      // Add conversion information to logs if conversion was performed
       const logData: any = {
-        userId,
-        text: result.text.substring(0, WHISPER_CONSTANTS.MAX_LOG_TEXT_LENGTH),
+        textHash: hashContent(result.text.substring(0, WHISPER_CONSTANTS.MAX_LOG_TEXT_LENGTH)),
         textLength: transcription.length,
         processingTimeMs,
         fileSizeBytes: processedBuffer.length,
@@ -236,7 +178,8 @@ export class WhisperService {
         logData.transcriptionTimeMs = processingTimeMs - conversionTimeMs;
       }
 
-      logger.info('Audio transcription completed successfully', logData);
+      logger.info('audio.transcription.succeeded', logData);
+      recordWhisperRequest('success', processingTimeMs);
 
       await this.usageTrackingService?.recordEvent({
         userId: userId?.toString(),
@@ -256,12 +199,12 @@ export class WhisperService {
     } catch (error) {
       const processingTimeMs = Date.now() - startTime;
 
-      logger.error('Audio transcription failed', {
-        userId,
-        fileUrl: this.sanitizeUrlForLogging(fileUrl),
-        error: (error as Error).message,
+      logger.error('audio.transcription.failed', {
+        fileUrlHash: hashContent(fileUrl),
+        ...serializeError(error),
         processingTimeMs,
       });
+      recordWhisperRequest('error', processingTimeMs);
 
       await this.usageTrackingService?.recordEvent({
         userId: userId?.toString(),
@@ -281,42 +224,48 @@ export class WhisperService {
     }
   }
 
-  /**
-   * Downloads audio file from the provided URL
-   *
-   * @param fileUrl - URL of the audio file
-   * @returns Promise resolving to audio file buffer
-   * @private
-   */
-  private async downloadAudioFile(fileUrl: string): Promise<Buffer> {
+  private async downloadAudioFile(fileUrl: string, context?: ProcessingContext): Promise<Buffer> {
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        requestId: context?.requestId || context?.jobId,
+        component: 'whisper_download',
+        chatId: context?.chatId,
+        jobId: context?.jobId,
+      }),
+    );
     try {
+      logger.info('audio.download.started', { fileUrlHash: hashContent(fileUrl) });
       const response = await fetch(fileUrl);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
-      // Validate content type if available
       const contentType = response.headers.get('content-type');
       if (contentType && !this.isValidAudioMimeType(contentType)) {
-        logger.warn('Unexpected content type for audio file', { contentType });
+        logger.warn('audio.download.unexpected_content_type', { contentType });
       }
 
       const arrayBuffer = await response.arrayBuffer();
       return Buffer.from(arrayBuffer);
     } catch (error) {
+      logger.error('audio.download.failed', {
+        fileUrlHash: hashContent(fileUrl),
+        ...serializeError(error),
+      });
       throw new Error(`Failed to download audio file: ${(error as Error).message}`);
     }
   }
 
-  /**
-   * Performs the actual transcription using OpenAI Whisper API
-   *
-   * @param audioFile - Audio file to transcribe
-   * @returns Promise resolving to transcribed text
-   * @private
-   */
-  private async performTranscription(audioFile: File): Promise<string> {
+  private async performTranscription(audioFile: File, context?: ProcessingContext): Promise<string> {
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        requestId: context?.requestId || context?.jobId,
+        component: 'whisper_api',
+        chatId: context?.chatId,
+        jobId: context?.jobId,
+      }),
+    );
     try {
       const transcription = await this.openai.audio.transcriptions.create({
         file: audioFile,
@@ -325,7 +274,6 @@ export class WhisperService {
         response_format: this.config.responseFormat,
       });
 
-      // Handle different response formats
       let transcribedText = '';
       if (typeof transcription === 'object' && 'text' in transcription) {
         transcribedText = transcription.text || '';
@@ -333,15 +281,14 @@ export class WhisperService {
         transcribedText = String(transcription || '');
       }
 
-      // Validate English content if enforcement is enabled
       if (this.config.enforceEnglishOnly && transcribedText) {
         this.validateEnglishContent(transcribedText);
       }
 
       return transcribedText;
     } catch (error) {
+      logger.error('audio.transcription.failed', serializeError(error));
       if (error instanceof Error) {
-        // Handle specific OpenAI API errors
         if (error.message.includes('Invalid file format')) {
           throw new Error('Unsupported audio format. Please use a supported audio file format.');
         }
@@ -354,15 +301,8 @@ export class WhisperService {
     }
   }
 
-  /**
-   * Validates that the transcribed content appears to be in English
-   * Logs warnings if non-English content is detected
-   *
-   * @param text - The transcribed text to validate
-   * @private
-   */
   private validateEnglishContent(text: string): void {
-    // Basic heuristic to detect potential non-English content
+    const logger = getLogger({ requestId: 'whisper-validation', component: 'whisper_service' });
     const nonLatinChars = /[^\x00-\x7F\s\p{P}]/u.test(text);
     const commonNonEnglishPatterns =
       /[\u00C0-\u017F\u0100-\u024F\u4E00-\u9FFF\u0400-\u04FF\u0590-\u05FF\u0600-\u06FF]/u.test(
@@ -371,7 +311,7 @@ export class WhisperService {
 
     if (nonLatinChars || commonNonEnglishPatterns) {
       logger.warn('Potential non-English content detected in transcription', {
-        textSample: text.substring(0, 50),
+        textSampleHash: hashContent(text.substring(0, 50)),
         hasNonLatinChars: nonLatinChars,
         hasNonEnglishPatterns: commonNonEnglishPatterns,
         enforceEnglishOnly: this.config.enforceEnglishOnly,
@@ -379,13 +319,6 @@ export class WhisperService {
     }
   }
 
-  /**
-   * Extracts file extension from URL
-   *
-   * @param url - File URL
-   * @returns File extension without dot, or null if not found
-   * @private
-   */
   private extractFileExtension(url: string): string | null {
     try {
       const urlObj = new URL(url);
@@ -402,66 +335,26 @@ export class WhisperService {
     }
   }
 
-  /**
-   * Gets MIME type from file extension
-   *
-   * @param extension - File extension
-   * @returns MIME type string
-   * @private
-   */
   private getMimeTypeFromExtension(extension: string): string {
+    const normalized = extension.toLowerCase();
     const mimeTypeMap: Record<string, string> = {
-      ogg: 'audio/ogg',
       mp3: 'audio/mpeg',
+      mpeg: 'audio/mpeg',
+      ogg: 'audio/ogg',
+      oga: 'audio/ogg',
       wav: 'audio/wav',
+      m4a: 'audio/mp4',
       mp4: 'audio/mp4',
-      m4a: 'audio/m4a',
-      aac: 'audio/aac',
       webm: 'audio/webm',
+      flac: 'audio/flac',
     };
 
-    return mimeTypeMap[extension.toLowerCase()] || 'audio/ogg';
+    return mimeTypeMap[normalized] || 'application/octet-stream';
   }
 
-  /**
-   * Validates if a MIME type is a supported audio format
-   *
-   * @param mimeType - MIME type to validate
-   * @returns True if the MIME type is supported
-   * @private
-   */
-  private isValidAudioMimeType(mimeType: string): boolean {
-    const normalizedMimeType = mimeType.split(';')[0].toLowerCase(); // Remove charset if present
-    return AudioMimeTypes.includes(normalizedMimeType as any);
-  }
-
-  /**
-   * Sanitizes URL for logging by truncating sensitive parts
-   *
-   * @param url - URL to sanitize
-   * @returns Sanitized URL string for logging
-   * @private
-   */
-  private sanitizeUrlForLogging(url: string): string {
-    if (url.length <= 100) {
-      return url;
-    }
-
-    return url.substring(0, 50) + '...[truncated]...' + url.substring(url.length - 20);
-  }
-
-  /**
-   * Gets current service configuration
-   *
-   * @returns Service configuration (excluding sensitive data)
-   */
-  getConfig(): Omit<WhisperConfig, 'apiKey'> {
-    return {
-      maxFileSizeBytes: this.config.maxFileSizeBytes,
-      model: this.config.model,
-      language: this.language,
-      responseFormat: this.config.responseFormat,
-      enforceEnglishOnly: this.config.enforceEnglishOnly,
-    };
+  private isValidAudioMimeType(contentType: string): boolean {
+    return (AudioMimeTypes as readonly string[]).some((mimeType) =>
+      contentType.toLowerCase().includes(mimeType.toLowerCase()),
+    );
   }
 }

--- a/src/services/external/todoist-api.service.ts
+++ b/src/services/external/todoist-api.service.ts
@@ -4,8 +4,8 @@
  *
  * @module TodoistAPIService
  */
-
-import { logger } from '../../utils/logger';
+import { extendTelemetryContext, getTelemetryContext } from '../../observability';
+import { createComponentLogger, serializeError } from '../../utils/logger';
 
 /**
  * Todoist API response interfaces
@@ -102,6 +102,10 @@ export class TodoistAPIService {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' = 'GET',
     body?: any,
   ): Promise<any> {
+    const logger = createComponentLogger(
+      'todoist_api',
+      extendTelemetryContext(getTelemetryContext(), { stage: 'todoist_request' }),
+    );
     const url = `${this.baseURL}${endpoint}`;
 
     const headers: Record<string, string> = {
@@ -119,7 +123,7 @@ export class TodoistAPIService {
     }
 
     try {
-      logger.debug('Making Todoist API request', {
+      logger.debug('todoist.request.started', {
         url,
         method,
         hasBody: !!body,
@@ -139,7 +143,7 @@ export class TodoistAPIService {
 
       const data = await response.json();
 
-      logger.debug('Todoist API response received', {
+      logger.debug('todoist.request.succeeded', {
         url,
         status: response.status,
         hasData: !!data,
@@ -147,10 +151,10 @@ export class TodoistAPIService {
 
       return data;
     } catch (error) {
-      logger.error('Todoist API request failed', {
+      logger.error('todoist.request.failed', {
         url,
         method,
-        error: (error as Error).message,
+        ...serializeError(error),
       });
       throw error;
     }
@@ -163,7 +167,8 @@ export class TodoistAPIService {
    * @returns Promise<TodoistTask> - Created task
    */
   async addTask(payload: CreateTaskPayload): Promise<TodoistTask> {
-    logger.info('Creating Todoist task', {
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.info('todoist.task.create.started', {
       content: payload.content,
       priority: payload.priority,
       hasDescription: !!payload.description,
@@ -171,7 +176,7 @@ export class TodoistAPIService {
 
     const task = await this.makeRequest('/tasks', 'POST', payload);
 
-    logger.info('Todoist task created successfully', {
+    logger.info('todoist.task.create.succeeded', {
       taskId: task.id,
       content: task.content,
     });
@@ -186,11 +191,12 @@ export class TodoistAPIService {
    * @returns Promise<TodoistTask> - Task details
    */
   async getTask(taskId: string): Promise<TodoistTask> {
-    logger.debug('Fetching Todoist task', { taskId });
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.debug('todoist.task.fetch.started', { taskId });
 
     const task = await this.makeRequest(`/tasks/${taskId}`);
 
-    logger.debug('Todoist task retrieved', {
+    logger.debug('todoist.task.fetch.succeeded', {
       taskId: task.id,
       content: task.content,
     });
@@ -214,7 +220,8 @@ export class TodoistAPIService {
       ids?: string[];
     } = {},
   ): Promise<TodoistTask[]> {
-    logger.debug('Fetching Todoist tasks', options);
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.debug('todoist.tasks.fetch.started', options);
 
     const params = new URLSearchParams();
 
@@ -230,7 +237,7 @@ export class TodoistAPIService {
     const endpoint = `/tasks${params.toString() ? '?' + params.toString() : ''}`;
     const tasks = await this.makeRequest(endpoint);
 
-    logger.debug('Todoist tasks retrieved', {
+    logger.debug('todoist.tasks.fetch.succeeded', {
       count: tasks.length,
       filter: options.filter,
     });
@@ -246,7 +253,8 @@ export class TodoistAPIService {
    * @returns Promise<TodoistTask> - Updated task
    */
   async updateTask(taskId: string, payload: UpdateTaskPayload): Promise<TodoistTask> {
-    logger.info('Updating Todoist task', {
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.info('todoist.task.update.started', {
       taskId,
       hasContent: !!payload.content,
       priority: payload.priority,
@@ -254,7 +262,7 @@ export class TodoistAPIService {
 
     const task = await this.makeRequest(`/tasks/${taskId}`, 'PUT', payload);
 
-    logger.info('Todoist task updated successfully', {
+    logger.info('todoist.task.update.succeeded', {
       taskId: task.id,
       content: task.content,
     });
@@ -269,11 +277,12 @@ export class TodoistAPIService {
    * @returns Promise<void>
    */
   async completeTask(taskId: string): Promise<void> {
-    logger.info('Completing Todoist task', { taskId });
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.info('todoist.task.complete.started', { taskId });
 
     await this.makeRequest(`/tasks/${taskId}/close`, 'POST');
 
-    logger.info('Todoist task completed successfully', { taskId });
+    logger.info('todoist.task.complete.succeeded', { taskId });
   }
 
   /**
@@ -283,11 +292,12 @@ export class TodoistAPIService {
    * @returns Promise<void>
    */
   async deleteTask(taskId: string): Promise<void> {
-    logger.info('Deleting Todoist task', { taskId });
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.info('todoist.task.delete.started', { taskId });
 
     await this.makeRequest(`/tasks/${taskId}`, 'DELETE');
 
-    logger.info('Todoist task deleted successfully', { taskId });
+    logger.info('todoist.task.delete.succeeded', { taskId });
   }
 
   /**
@@ -296,11 +306,12 @@ export class TodoistAPIService {
    * @returns Promise<TodoistProject[]> - Array of projects
    */
   async getProjects(): Promise<TodoistProject[]> {
-    logger.debug('Fetching Todoist projects');
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.debug('todoist.projects.fetch.started');
 
     const projects = await this.makeRequest('/projects');
 
-    logger.debug('Todoist projects retrieved', {
+    logger.debug('todoist.projects.fetch.succeeded', {
       count: projects.length,
     });
 
@@ -338,7 +349,8 @@ export class TodoistAPIService {
       offset?: number;
     } = {},
   ): Promise<any[]> {
-    logger.debug('Fetching completed Todoist tasks', options);
+    const logger = createComponentLogger('todoist_api', getTelemetryContext());
+    logger.debug('todoist.completed_tasks.fetch.started', options);
 
     // Note: This uses the Sync API endpoint for completed tasks
     const syncUrl = 'https://api.todoist.com/sync/v9/completed/get_all';
@@ -367,15 +379,13 @@ export class TodoistAPIService {
 
       const data = await response.json();
 
-      logger.debug('Completed Todoist tasks retrieved', {
+      logger.debug('todoist.completed_tasks.fetch.succeeded', {
         count: data.items?.length || 0,
       });
 
       return data.items || [];
     } catch (error) {
-      logger.error('Failed to fetch completed tasks', {
-        error: (error as Error).message,
-      });
+      logger.error('todoist.completed_tasks.fetch.failed', serializeError(error));
       throw error;
     }
   }

--- a/src/services/telegram/file.service.ts
+++ b/src/services/telegram/file.service.ts
@@ -1,5 +1,6 @@
 // src/services/telegram/file.service.ts
-import { logger } from '../../utils/logger';
+import { extendTelemetryContext, getTelemetryContext } from '../../observability';
+import { createComponentLogger, serializeError } from '../../utils/logger';
 import { Telegram } from 'telegraf';
 import { AudioMimeTypes } from '../../utils/constants';
 
@@ -24,6 +25,10 @@ export class FileService {
    * Gets the download URL for a file from Telegram
    */
   async getFileUrl(fileId: string): Promise<string> {
+    const logger = createComponentLogger(
+      'telegram_file',
+      extendTelemetryContext(getTelemetryContext(), { stage: 'file_url' }),
+    );
     try {
       const file = await this.telegram.getFile(fileId);
       if (!file.file_path) {
@@ -31,9 +36,9 @@ export class FileService {
       }
       return `https://api.telegram.org/file/bot${this.botToken}/${file.file_path}`;
     } catch (error) {
-      logger.error('Error getting file URL', {
-        error: (error as Error).message,
-        fileId
+      logger.error('audio.download.failed', {
+        fileId,
+        ...serializeError(error),
       });
       throw new Error(`Failed to get file URL: ${(error as Error).message}`);
     }
@@ -43,6 +48,10 @@ export class FileService {
    * Downloads a file from Telegram
    */
   async downloadFile(fileId: string): Promise<Buffer> {
+    const logger = createComponentLogger(
+      'telegram_file',
+      extendTelemetryContext(getTelemetryContext(), { stage: 'download' }),
+    );
     try {
       const fileUrl = await this.getFileUrl(fileId);
       const response = await fetch(fileUrl);
@@ -53,9 +62,9 @@ export class FileService {
 
       return Buffer.from(await response.arrayBuffer());
     } catch (error) {
-      logger.error('Error downloading file', {
-        error: (error as Error).message,
-        fileId
+      logger.error('audio.download.failed', {
+        fileId,
+        ...serializeError(error),
       });
       throw error;
     }

--- a/src/services/telegram/handlers/command-handlers.ts
+++ b/src/services/telegram/handlers/command-handlers.ts
@@ -1,14 +1,11 @@
-// src/services/telegram/handlers/command-handlers.ts
 import { Context } from 'telegraf';
-import { logger } from '../../../utils/logger';
+import { extendTelemetryContext, getTelemetryContext } from '../../../observability';
+import { getLogger } from '../../../utils/logger';
 import { BotActivityService } from '../bot-activity.service';
 import { BotStatusService } from '../bot-status.service';
 import { ConversationStoreService } from '../../persistence';
 import { Message } from 'telegraf/typings/core/types/typegram';
 
-/**
- * Handles bot commands
- */
 export class CommandHandlers {
   constructor(
     private readonly activityService: BotActivityService,
@@ -21,20 +18,29 @@ export class CommandHandlers {
     const chatId = ctx.chat?.id;
     const updateId = ctx.update && 'update_id' in ctx.update ? ctx.update.update_id : undefined;
     const telegramMessageId = ctx.message && 'message_id' in ctx.message ? ctx.message.message_id : undefined;
-    logger.info('User requested help', { userId });
+    const logger = getLogger(
+      extendTelemetryContext(getTelemetryContext(), {
+        component: 'telegram_command',
+        chatId,
+        userId: userId ? String(userId) : undefined,
+        messageType: 'command',
+      }),
+    );
+    logger.info('telegram.command.received', { command: 'help' });
     this.activityService.recordActivity('command_help');
 
-    const incomingMessage = userId && chatId
-      ? await this.conversationStore?.createIncomingMessage({
-          telegramUpdateId: updateId,
-          telegramMessageId,
-          chatId: chatId.toString(),
-          userId: userId.toString(),
-          messageType: 'command',
-          contentText: '/help',
-          status: 'processed',
-        })
-      : null;
+    const incomingMessage =
+      userId && chatId
+        ? await this.conversationStore?.createIncomingMessage({
+            telegramUpdateId: updateId,
+            telegramMessageId,
+            chatId: chatId.toString(),
+            userId: userId.toString(),
+            messageType: 'command',
+            contentText: '/help',
+            status: 'processed',
+          })
+        : null;
 
     const helpMessage = `🆘 *JarvisMCP Help*
 
@@ -72,20 +78,29 @@ export class CommandHandlers {
     const chatId = ctx.chat?.id;
     const updateId = ctx.update && 'update_id' in ctx.update ? ctx.update.update_id : undefined;
     const telegramMessageId = ctx.message && 'message_id' in ctx.message ? ctx.message.message_id : undefined;
-    logger.info('User requested status', { userId });
+    const logger = getLogger(
+      extendTelemetryContext(getTelemetryContext(), {
+        component: 'telegram_command',
+        chatId,
+        userId: userId ? String(userId) : undefined,
+        messageType: 'command',
+      }),
+    );
+    logger.info('telegram.command.received', { command: 'status' });
     this.activityService.recordActivity('command_status');
 
-    const incomingMessage = userId && chatId
-      ? await this.conversationStore?.createIncomingMessage({
-          telegramUpdateId: updateId,
-          telegramMessageId,
-          chatId: chatId.toString(),
-          userId: userId.toString(),
-          messageType: 'command',
-          contentText: '/status',
-          status: 'processed',
-        })
-      : null;
+    const incomingMessage =
+      userId && chatId
+        ? await this.conversationStore?.createIncomingMessage({
+            telegramUpdateId: updateId,
+            telegramMessageId,
+            chatId: chatId.toString(),
+            userId: userId.toString(),
+            messageType: 'command',
+            contentText: '/status',
+            status: 'processed',
+          })
+        : null;
 
     const statusMessage = await this.statusService.getFormattedStatus();
     const reply = (await ctx.reply(statusMessage, { parse_mode: 'Markdown' })) as Message.TextMessage;

--- a/src/services/telegram/handlers/message-handlers.ts
+++ b/src/services/telegram/handlers/message-handlers.ts
@@ -1,5 +1,6 @@
 import { Context } from 'telegraf';
-import { logger } from '../../../utils/logger';
+import { extendTelemetryContext, getTelemetryContext } from '../../../observability';
+import { getLogger, serializeError } from '../../../utils/logger';
 import { FileService } from '../file.service';
 import { BotActivityService } from '../bot-activity.service';
 import { TelegramUpdateIntakeService } from '../telegram-update-intake.service';
@@ -18,12 +19,10 @@ export class MessageHandlers {
   async handleText(ctx: Context): Promise<void> {
     if (!ctx.message || !('text' in ctx.message)) return;
 
-    const userId = ctx.from?.id;
-    const chatId = ctx.chat?.id;
+    const context = this.createMessageContext(ctx, 'text');
+    const logger = getLogger(context);
 
-    logger.info('Received text message', {
-      userId,
-      chatId,
+    logger.info('telegram.message.received', {
       username: ctx.from?.username,
       messageLength: ctx.message.text.length,
     });
@@ -37,12 +36,9 @@ export class MessageHandlers {
         ctx.message.message_id,
       );
       await this.jobService.attachAcknowledgement(enqueued.job.id, ack.message_id);
+      logger.info('telegram.reply.sent', { replyLength: enqueued.acknowledgement.length });
     } catch (error) {
-      logger.error('Error queueing text message', {
-        userId,
-        chatId,
-        error: (error as Error).message,
-      });
+      logger.error('message.route.failed', serializeError(error));
       await this.responseService.sendFailureResponse(
         ctx.chat!.id,
         '❌ Sorry, I had trouble queuing your message.',
@@ -53,12 +49,10 @@ export class MessageHandlers {
   async handleVoice(ctx: Context): Promise<void> {
     if (!ctx.message || !('voice' in ctx.message)) return;
 
-    const userId = ctx.from?.id;
-    const chatId = ctx.chat?.id;
+    const context = this.createMessageContext(ctx, 'audio');
+    const logger = getLogger(context);
 
-    logger.info('Voice message received', {
-      userId,
-      chatId,
+    logger.info('telegram.message.received', {
       duration: ctx.message.voice.duration,
       fileSize: ctx.message.voice.file_size,
     });
@@ -72,12 +66,9 @@ export class MessageHandlers {
         ctx.message.message_id,
       );
       await this.jobService.attachAcknowledgement(enqueued.job.id, ack.message_id);
+      logger.info('telegram.reply.sent', { replyLength: enqueued.acknowledgement.length });
     } catch (error) {
-      logger.error('Error queueing voice message', {
-        userId,
-        chatId,
-        error: (error as Error).message,
-      });
+      logger.error('message.route.failed', serializeError(error));
       await this.responseService.sendFailureResponse(
         ctx.chat!.id,
         '❌ Sorry, I had trouble queuing your voice message.',
@@ -96,13 +87,11 @@ export class MessageHandlers {
     if (!ctx.message || !('document' in ctx.message)) return;
 
     const document = ctx.message.document;
-    const userId = ctx.from?.id;
-    const chatId = ctx.chat?.id;
+    const context = this.createMessageContext(ctx, 'audio_document');
+    const logger = getLogger(context);
 
     if (!this.fileService.isAudioFile(document.mime_type)) {
-      logger.info('Non-audio document received', {
-        userId,
-        chatId,
+      logger.info('telegram.message.received', {
         mimeType: document.mime_type,
         fileName: document.file_name,
       });
@@ -123,12 +112,11 @@ export class MessageHandlers {
         ctx.message.message_id,
       );
       await this.jobService.attachAcknowledgement(enqueued.job.id, ack.message_id);
+      logger.info('telegram.reply.sent', { replyLength: enqueued.acknowledgement.length });
     } catch (error) {
-      logger.error('Error queueing audio document', {
-        userId,
-        chatId,
+      logger.error('message.route.failed', {
         fileName: document.file_name,
-        error: (error as Error).message,
+        ...serializeError(error),
       });
       await this.responseService.sendFailureResponse(
         ctx.chat!.id,
@@ -138,12 +126,9 @@ export class MessageHandlers {
   }
 
   async handleUnknown(ctx: Context): Promise<void> {
-    const userId = ctx.from?.id;
-    const chatId = ctx.chat?.id;
+    const logger = getLogger(this.createMessageContext(ctx, 'unknown'));
 
-    logger.info('Unhandled message type received', {
-      userId,
-      chatId,
+    logger.info('telegram.message.received', {
       messageType: 'unknown',
     });
     this.activityService.recordActivity('message_unknown');
@@ -157,12 +142,9 @@ export class MessageHandlers {
   private async processAudioFile(ctx: Context): Promise<void> {
     if (!ctx.message || !('audio' in ctx.message)) return;
 
-    const userId = ctx.from?.id;
-    const chatId = ctx.chat?.id;
+    const logger = getLogger(this.createMessageContext(ctx, 'audio'));
 
-    logger.info('Audio file received', {
-      userId,
-      chatId,
+    logger.info('telegram.message.received', {
       fileName: ctx.message.audio.file_name || 'audio_file',
       mimeType: ctx.message.audio.mime_type,
       fileSize: ctx.message.audio.file_size,
@@ -177,16 +159,27 @@ export class MessageHandlers {
         ctx.message.message_id,
       );
       await this.jobService.attachAcknowledgement(enqueued.job.id, ack.message_id);
+      logger.info('telegram.reply.sent', { replyLength: enqueued.acknowledgement.length });
     } catch (error) {
-      logger.error('Error queueing audio file', {
-        userId,
-        chatId,
-        error: (error as Error).message,
-      });
+      logger.error('message.route.failed', serializeError(error));
       await this.responseService.sendFailureResponse(
         ctx.chat!.id,
         '❌ Sorry, I had trouble queuing your audio file.',
       );
     }
+  }
+
+  private createMessageContext(
+    ctx: Context,
+    messageType: 'text' | 'audio' | 'audio_document' | 'unknown',
+  ) {
+    return extendTelemetryContext(getTelemetryContext(), {
+      chatId: ctx.chat?.id,
+      userId: ctx.from?.id ? String(ctx.from.id) : undefined,
+      updateId: (ctx.update as any)?.update_id,
+      messageType,
+      component: 'telegram_message',
+      stage: 'received',
+    });
   }
 }

--- a/src/services/telegram/message-processor.service.ts
+++ b/src/services/telegram/message-processor.service.ts
@@ -1,4 +1,9 @@
-import { logger } from '../../utils/logger';
+import {
+  extendTelemetryContext,
+  recordMessageProcessingDuration,
+  recordMessageProcessingFailure,
+} from '../../observability';
+import { getLogger, serializeError } from '../../utils/logger';
 import { TextProcessorService } from './processors/text-processor.service';
 import { AudioProcessorService } from './processors/audio-processor.service';
 import { ToolDispatcher } from '../../types/tool.types';
@@ -19,13 +24,8 @@ export class MessageProcessorService {
     userId?: number,
     context?: ProcessingContext,
   ): Promise<string> {
-    logger.info('Delegating text message processing', {
-      jobId: context?.jobId,
-      userId,
-      messageLength: text.length,
-    });
-
-    return this.textProcessor.processTextMessage(text, userId, context);
+    const result = await this.processTextMessageDetailed(text, userId, context);
+    return result.responseText;
   }
 
   async processTextMessageDetailed(
@@ -33,7 +33,37 @@ export class MessageProcessorService {
     userId?: number,
     context?: ProcessingContext,
   ): Promise<ProcessorResponse> {
-    return this.textProcessor.processTextMessageDetailed(text, userId, context);
+    const scopedContext = extendTelemetryContext(context, {
+      requestId: context?.requestId || context?.jobId,
+      component: 'message_processor',
+      userId: userId ? String(userId) : context?.userId,
+      chatId: context?.chatId,
+      jobId: context?.jobId,
+      messageType: 'text',
+      stage: 'route',
+    });
+    const logger = getLogger(scopedContext);
+    const startTime = Date.now();
+
+    logger.info('message.route.started', {
+      messageLength: text.length,
+    });
+
+    try {
+      const response = await this.textProcessor.processTextMessageDetailed(text, userId, context);
+      recordMessageProcessingDuration('text', Date.now() - startTime);
+      logger.info('message.route.completed', {
+        durationMs: Date.now() - startTime,
+      });
+      return response;
+    } catch (error) {
+      recordMessageProcessingFailure('text', 'route');
+      logger.error('message.route.failed', {
+        ...serializeError(error),
+        durationMs: Date.now() - startTime,
+      });
+      throw error;
+    }
   }
 
   async processAudioMessage(
@@ -41,13 +71,8 @@ export class MessageProcessorService {
     userId?: number,
     context?: ProcessingContext,
   ): Promise<string> {
-    logger.info('Delegating audio message processing', {
-      jobId: context?.jobId,
-      userId,
-      fileUrl: fileUrl.substring(0, 50) + '...',
-    });
-
-    return this.audioProcessor.processAudioMessage(fileUrl, userId, context);
+    const result = await this.processAudioMessageDetailed(fileUrl, userId, context);
+    return result.responseText;
   }
 
   async processAudioMessageDetailed(
@@ -55,7 +80,37 @@ export class MessageProcessorService {
     userId?: number,
     context?: ProcessingContext,
   ): Promise<ProcessorResponse> {
-    return this.audioProcessor.processAudioMessageDetailed(fileUrl, userId, context);
+    const scopedContext = extendTelemetryContext(context, {
+      requestId: context?.requestId || context?.jobId,
+      component: 'message_processor',
+      userId: userId ? String(userId) : context?.userId,
+      chatId: context?.chatId,
+      jobId: context?.jobId,
+      messageType: 'audio',
+      stage: 'route',
+    });
+    const logger = getLogger(scopedContext);
+    const startTime = Date.now();
+
+    logger.info('message.route.started', {
+      hasFileUrl: !!fileUrl,
+    });
+
+    try {
+      const response = await this.audioProcessor.processAudioMessageDetailed(fileUrl, userId, context);
+      recordMessageProcessingDuration('audio', Date.now() - startTime);
+      logger.info('message.route.completed', {
+        durationMs: Date.now() - startTime,
+      });
+      return response;
+    } catch (error) {
+      recordMessageProcessingFailure('audio', 'route');
+      logger.error('message.route.failed', {
+        ...serializeError(error),
+        durationMs: Date.now() - startTime,
+      });
+      throw error;
+    }
   }
 
   async processAudioDocument(
@@ -65,14 +120,14 @@ export class MessageProcessorService {
     userId?: number,
     context?: ProcessingContext,
   ): Promise<string> {
-    logger.info('Delegating audio document processing', {
-      jobId: context?.jobId,
-      userId,
+    const result = await this.processAudioDocumentDetailed(
+      fileUrl,
       fileName,
       mimeType,
-    });
-
-    return this.audioProcessor.processAudioDocument(fileUrl, fileName, mimeType, userId, context);
+      userId,
+      context,
+    );
+    return result.responseText;
   }
 
   async processAudioDocumentDetailed(
@@ -82,13 +137,44 @@ export class MessageProcessorService {
     userId?: number,
     context?: ProcessingContext,
   ): Promise<ProcessorResponse> {
-    return this.audioProcessor.processAudioDocumentDetailed(
-      fileUrl,
+    const scopedContext = extendTelemetryContext(context, {
+      requestId: context?.requestId || context?.jobId,
+      component: 'message_processor',
+      userId: userId ? String(userId) : context?.userId,
+      chatId: context?.chatId,
+      jobId: context?.jobId,
+      messageType: 'audio_document',
+      stage: 'route',
+    });
+    const logger = getLogger(scopedContext);
+    const startTime = Date.now();
+
+    logger.info('message.route.started', {
       fileName,
       mimeType,
-      userId,
-      context,
-    );
+    });
+
+    try {
+      const response = await this.audioProcessor.processAudioDocumentDetailed(
+        fileUrl,
+        fileName,
+        mimeType,
+        userId,
+        context,
+      );
+      recordMessageProcessingDuration('audio_document', Date.now() - startTime);
+      logger.info('message.route.completed', {
+        durationMs: Date.now() - startTime,
+      });
+      return response;
+    } catch (error) {
+      recordMessageProcessingFailure('audio_document', 'route');
+      logger.error('message.route.failed', {
+        ...serializeError(error),
+        durationMs: Date.now() - startTime,
+      });
+      throw error;
+    }
   }
 
   async processMessage(
@@ -100,10 +186,16 @@ export class MessageProcessorService {
     },
     userId?: number,
   ): Promise<string> {
-    logger.info('Processing message with automatic routing', {
-      userId,
-      messageType: messageData.type,
-    });
+    const logger = getLogger(
+      extendTelemetryContext(undefined, {
+        component: 'message_processor',
+        userId: userId ? String(userId) : undefined,
+        messageType: messageData.type,
+        stage: 'route',
+      }),
+    );
+
+    logger.info('message.route.started', { messageType: messageData.type });
 
     switch (messageData.type) {
       case 'text':
@@ -121,10 +213,7 @@ export class MessageProcessorService {
           userId,
         );
       default:
-        logger.warn('Unknown message type received', {
-          userId,
-          messageType: messageData.type,
-        });
+        logger.warn('message.route.failed', { messageType: messageData.type });
         return (
           `🤖 I received a message, but I'm not sure how to process this type of content.\n` +
           `📝 Supported types: text messages, voice notes, and audio files.\n` +

--- a/src/services/telegram/processors/audio-processor.service.ts
+++ b/src/services/telegram/processors/audio-processor.service.ts
@@ -1,4 +1,8 @@
-import { logger } from '../../../utils/logger';
+import {
+  extendTelemetryContext,
+  recordMessageProcessingFailure,
+} from '../../../observability';
+import { getLogger, serializeError } from '../../../utils/logger';
 import { WhisperService } from '../../ai/whisper.service';
 import { GPTService } from '../../ai/gpt.service';
 import { ProcessorResponse, ProcessingContext } from '../../../types/processing.types';
@@ -35,10 +39,19 @@ export class AudioProcessorService {
     userId?: number,
     context?: ProcessingContext,
   ): Promise<ProcessorResponse> {
-    logger.info('Processing audio message', {
+    const scopedContext = extendTelemetryContext(context, {
+      requestId: context?.requestId || context?.jobId,
+      component: 'audio_processor',
+      userId: userId ? String(userId) : context?.userId,
+      chatId: context?.chatId,
       jobId: context?.jobId,
-      userId,
-      fileUrl: fileUrl.substring(0, 50) + '...',
+      messageType: 'audio',
+      stage: 'process',
+    });
+    const logger = getLogger(scopedContext);
+
+    logger.info('message.route.started', {
+      hasFileUrl: !!fileUrl,
     });
 
     try {
@@ -68,12 +81,7 @@ export class AudioProcessorService {
           transcriptionText: text,
         };
       } catch (gptError) {
-        logger.warn('Failed to process transcribed audio with GPT', {
-          jobId: context?.jobId,
-          userId,
-          transcribedText: text.substring(0, 100),
-          error: (gptError as Error).message,
-        });
+        logger.warn('openai.chat.failed', serializeError(gptError));
 
         return {
           responseText:
@@ -86,11 +94,8 @@ export class AudioProcessorService {
         };
       }
     } catch (error) {
-      logger.error('Failed to process audio message', {
-        jobId: context?.jobId,
-        userId,
-        error: (error as Error).message,
-      });
+      recordMessageProcessingFailure('audio', 'audio_processor');
+      logger.error('message.route.failed', serializeError(error));
 
       return {
         responseText: this.handleAudioProcessingError(error as Error),
@@ -122,9 +127,18 @@ export class AudioProcessorService {
     userId?: number,
     context?: ProcessingContext,
   ): Promise<ProcessorResponse> {
-    logger.info('Processing audio document', {
+    const scopedContext = extendTelemetryContext(context, {
+      requestId: context?.requestId || context?.jobId,
+      component: 'audio_processor',
+      userId: userId ? String(userId) : context?.userId,
+      chatId: context?.chatId,
       jobId: context?.jobId,
-      userId,
+      messageType: 'audio_document',
+      stage: 'process',
+    });
+    const logger = getLogger(scopedContext);
+
+    logger.info('message.route.started', {
       fileName,
       mimeType,
     });
@@ -159,12 +173,9 @@ export class AudioProcessorService {
           transcriptionText: text,
         };
       } catch (gptError) {
-        logger.warn('Failed to process transcribed audio document with GPT', {
-          jobId: context?.jobId,
-          userId,
+        logger.warn('openai.chat.failed', {
           fileName,
-          transcribedText: text.substring(0, 100),
-          error: (gptError as Error).message,
+          ...serializeError(gptError),
         });
 
         return {
@@ -179,12 +190,11 @@ export class AudioProcessorService {
         };
       }
     } catch (error) {
-      logger.error('Failed to process audio document', {
-        jobId: context?.jobId,
-        userId,
+      recordMessageProcessingFailure('audio_document', 'audio_processor');
+      logger.error('message.route.failed', {
         fileName,
         mimeType,
-        error: (error as Error).message,
+        ...serializeError(error),
       });
 
       return {

--- a/src/services/telegram/processors/text-processor.service.ts
+++ b/src/services/telegram/processors/text-processor.service.ts
@@ -1,4 +1,9 @@
-import { logger } from '../../../utils/logger';
+import {
+  extendTelemetryContext,
+  hashContent,
+  recordMessageProcessingFailure,
+} from '../../../observability';
+import { getLogger, serializeError } from '../../../utils/logger';
 import { GPTService } from '../../ai';
 import { ToolDispatcher } from '../../../types/tool.types';
 import { ProcessorResponse, ProcessingContext } from '../../../types/processing.types';
@@ -21,19 +26,27 @@ export class TextProcessorService {
     userId?: number,
     context?: ProcessingContext,
   ): Promise<ProcessorResponse> {
-    logger.info('Processing text message', {
+    const scopedContext = extendTelemetryContext(context, {
+      requestId: context?.requestId || context?.jobId,
+      component: 'text_processor',
+      userId: userId ? String(userId) : context?.userId,
+      chatId: context?.chatId,
       jobId: context?.jobId,
-      userId,
+      messageType: 'text',
+      stage: 'process',
+    });
+    const logger = getLogger(scopedContext);
+
+    logger.info('message.route.started', {
       messageLength: text.length,
+      messageHash: hashContent(text),
     });
 
     try {
       await context?.onStage?.('gpt.processing');
       const response = await this.gptService.processMessageDetailed(text, userId?.toString(), context);
 
-      logger.info('Text message processed successfully', {
-        jobId: context?.jobId,
-        userId,
+      logger.info('message.route.completed', {
         messageLength: text.length,
         responseLength: response.response.length,
       });
@@ -43,11 +56,10 @@ export class TextProcessorService {
         processingTimeMs: response.processingTimeMs,
       };
     } catch (error) {
-      logger.error('Failed to process text message', {
-        jobId: context?.jobId,
-        userId,
+      recordMessageProcessingFailure('text', 'text_processor');
+      logger.error('message.route.failed', {
         messageLength: text.length,
-        error: (error as Error).message,
+        ...serializeError(error),
       });
 
       return {
@@ -76,7 +88,7 @@ export class TextProcessorService {
 
     return (
       `I encountered an issue processing your request.\n` +
-      `💭 Your message: "${text.length > 100 ? text.substring(0, 100) + '...' : text}"\n\n` +
+      `💭 Message length: ${text.length} characters\n\n` +
       `🔄 Please try again, and I'll do my best to help!`
     );
   }

--- a/src/services/telegram/telegram-bot.service.ts
+++ b/src/services/telegram/telegram-bot.service.ts
@@ -1,4 +1,4 @@
-import { logger } from '../../utils/logger';
+import { logger, getLogger, serializeError } from '../../utils/logger';
 import { Telegraf, Context } from 'telegraf';
 import { Message } from 'telegraf/typings/core/types/typegram';
 import { TelegramHandlers } from './handlers/telegram-handlers';
@@ -12,6 +12,13 @@ import { ConversationStoreService, UsageTrackingService } from '../persistence';
 import { TelegramUpdateIntakeService } from './telegram-update-intake.service';
 import { TelegramResponseService } from './telegram-response.service';
 import { JobService } from '../jobs/job.service';
+import {
+  extendTelemetryContext,
+  getTelemetryContext,
+  recordTelegramUpdate,
+  runWithTelemetryContext,
+  TelemetryContext,
+} from '../../observability';
 
 export class TelegramBotService {
   public readonly bot: Telegraf<Context>;
@@ -56,7 +63,7 @@ export class TelegramBotService {
     this.setupBotHandlers();
     this.setupErrorHandling();
 
-    logger.info('Telegram bot initialized successfully');
+    logger.info('telegram.bot.initialized');
   }
 
   private setupBotHandlers(): void {
@@ -66,19 +73,25 @@ export class TelegramBotService {
   private setupErrorHandling(): void {
     this.bot.catch(async (err: unknown, ctx: Context) => {
       const error = err as Error;
-      logger.error('Bot error occurred', {
-        error: error.message,
-        stack: error.stack,
-        userId: ctx.from?.id,
-        chatId: ctx.chat?.id,
+      const context = extendTelemetryContext(this.getContextFromTelegram(ctx), {
+        component: 'telegram_bot',
+        stage: 'bot_error',
+      });
+      const scopedLogger = getLogger(context);
+
+      scopedLogger.error('telegram.update.failed', {
+        ...serializeError(error),
       });
 
       try {
         await ctx.reply('❌ Sorry, something went wrong. Please try again.');
+        scopedLogger.info('telegram.reply.sent', {
+          replyLength: 47,
+        });
       } catch (replyError) {
-        logger.error('Failed to send error message', {
-          originalError: error.message,
-          replyError: (replyError as Error).message,
+        scopedLogger.error('telegram.reply.failed', {
+          ...serializeError(replyError),
+          originalErrorMessage: error.message,
         });
       }
     });
@@ -88,7 +101,7 @@ export class TelegramBotService {
     try {
       const fullWebhookUrl = `${webhookUrl}/webhook/${secretToken}`;
 
-      logger.info('Setting up webhook', { url: fullWebhookUrl });
+      logger.info('telegram.webhook.setup_requested', { webhookUrl });
 
       await this.syncCommands();
 
@@ -98,10 +111,10 @@ export class TelegramBotService {
         drop_pending_updates: true,
       });
 
-      logger.info('Webhook configured successfully');
+      logger.info('telegram.webhook.configured');
     } catch (error) {
-      logger.error('Failed to set webhook', {
-        error: (error as Error).message,
+      logger.error('telegram.webhook.failed', {
+        ...serializeError(error),
         webhookUrl,
       });
       throw new Error(`Webhook setup failed: ${(error as Error).message}`);
@@ -110,40 +123,64 @@ export class TelegramBotService {
 
   async removeWebhook(): Promise<void> {
     await this.bot.telegram.deleteWebhook({ drop_pending_updates: true });
-    logger.info('Webhook removed successfully');
+    logger.info('telegram.webhook.removed');
   }
 
-  async handleUpdate(update: any): Promise<void> {
+  async handleUpdate(update: any, context?: TelemetryContext): Promise<void> {
+    const enrichedContext = extendTelemetryContext(context, {
+      component: 'telegram_update',
+      chatId: update?.message?.chat?.id || update?.callback_query?.message?.chat?.id,
+      userId:
+        update?.message?.from?.id?.toString() || update?.callback_query?.from?.id?.toString(),
+      stage: 'update',
+    });
+    const scopedLogger = getLogger(enrichedContext);
+
     try {
-      await this.bot.handleUpdate(update);
+      const updateType = this.getUpdateType(update);
+      scopedLogger.info('telegram.update.received', {
+        updateType,
+      });
+      recordTelegramUpdate(updateType);
+
+      await runWithTelemetryContext(enrichedContext, () => this.bot.handleUpdate(update));
     } catch (error) {
-      logger.error('Error handling Telegram update', {
-        updateId: update.update_id,
-        error: (error as Error).message,
+      scopedLogger.error('telegram.update.failed', {
+        ...serializeError(error),
       });
       throw error;
     }
   }
 
   async sendMessage(chatId: number, text: string, options?: any): Promise<Message.TextMessage> {
-    return this.bot.telegram.sendMessage(chatId, text, options);
+    const scopedLogger = getLogger(
+      this.getContextFromOptions(options, { component: 'telegram_send_message', chatId }),
+    );
+
+    const sentMessage = await this.bot.telegram.sendMessage(chatId, text, options);
+    scopedLogger.info('telegram.reply.sent', {
+      chatId,
+      textLength: text.length,
+    });
+
+    return sentMessage;
   }
 
   async getBotInfo(): Promise<any> {
     const botInfo = await this.bot.telegram.getMe();
-    logger.debug('Retrieved bot info', { username: botInfo.username });
+    logger.debug('telegram.bot.info_retrieved', { username: botInfo.username });
     return botInfo;
   }
 
   async startPolling(): Promise<void> {
     await this.syncCommands();
     await this.bot.launch();
-    logger.info('Bot started polling for updates');
+    logger.info('telegram.bot.polling_started');
   }
 
   async stop(): Promise<void> {
     this.bot.stop();
-    logger.info('Bot stopped successfully');
+    logger.info('telegram.bot.stopped');
   }
 
   private async syncCommands(): Promise<void> {
@@ -151,5 +188,38 @@ export class TelegramBotService {
       { command: 'help', description: 'Show available commands and supported inputs' },
       { command: 'status', description: 'Show bot health, uptime, and dependency status' },
     ]);
+  }
+
+  private getUpdateType(update: any): string {
+    if (update?.message?.voice) return 'voice';
+    if (update?.message?.audio) return 'audio';
+    if (update?.message?.document) return 'document';
+    if (update?.message?.text) return 'text';
+    return 'unknown';
+  }
+
+  private getContextFromTelegram(ctx: Context): TelemetryContext | undefined {
+    const currentContext = getTelemetryContext();
+    if (!currentContext) {
+      return undefined;
+    }
+
+    return extendTelemetryContext(currentContext, {
+      updateId: (ctx.update as any)?.update_id,
+      chatId: ctx.chat?.id,
+      userId: ctx.from?.id ? String(ctx.from.id) : undefined,
+    });
+  }
+
+  private getContextFromOptions(
+    options: any,
+    fallback: Partial<TelemetryContext>,
+  ): TelemetryContext | undefined {
+    if (options?.telemetryContext) {
+      return extendTelemetryContext(options.telemetryContext, fallback);
+    }
+
+    const currentContext = getTelemetryContext();
+    return currentContext ? extendTelemetryContext(currentContext, fallback) : undefined;
   }
 }

--- a/src/services/tools/direct-tool-dispatcher.service.ts
+++ b/src/services/tools/direct-tool-dispatcher.service.ts
@@ -1,10 +1,5 @@
-/**
- * Direct tool call dispatcher that executes Todoist operations via REST API
- *
- * @module DirectToolCallDispatcher
- */
-
-import { logger } from '../../utils/logger';
+import { extendTelemetryContext, recordToolCall } from '../../observability';
+import { getLogger, serializeError } from '../../utils/logger';
 import {
   ToolCall,
   ToolExecutionContext,
@@ -14,48 +9,17 @@ import {
 } from '../../types/tool.types';
 import { TodoistAPIService } from '../external/todoist-api.service';
 
-/**
- * Service for dispatching tool calls directly to external APIs
- */
 export class DirectToolCallDispatcher implements ToolDispatcher {
   private readonly todoistService: TodoistAPIService;
   private static readonly userWriteLocks = new Map<string, Promise<void>>();
   private readonly executionPolicies: Record<string, ToolExecutionPolicy> = {
-    add_todoist_task: {
-      mutatesState: true,
-      resourceType: 'todoist_task',
-      executionMode: 'ordered_write',
-    },
-    get_todoist_task: {
-      mutatesState: false,
-      resourceType: 'todoist_task',
-      executionMode: 'parallel_read',
-    },
-    get_tasks: {
-      mutatesState: false,
-      resourceType: 'todoist_task',
-      executionMode: 'parallel_read',
-    },
-    update_todoist_task: {
-      mutatesState: true,
-      resourceType: 'todoist_task',
-      executionMode: 'ordered_write',
-    },
-    complete_task: {
-      mutatesState: true,
-      resourceType: 'todoist_task',
-      executionMode: 'ordered_write',
-    },
-    delete_todoist_task: {
-      mutatesState: true,
-      resourceType: 'todoist_task',
-      executionMode: 'ordered_write',
-    },
-    get_completed_todoist_tasks: {
-      mutatesState: false,
-      resourceType: 'todoist_task',
-      executionMode: 'parallel_read',
-    },
+    add_todoist_task: { mutatesState: true, resourceType: 'todoist_task', executionMode: 'ordered_write' },
+    get_todoist_task: { mutatesState: false, resourceType: 'todoist_task', executionMode: 'parallel_read' },
+    get_tasks: { mutatesState: false, resourceType: 'todoist_task', executionMode: 'parallel_read' },
+    update_todoist_task: { mutatesState: true, resourceType: 'todoist_task', executionMode: 'ordered_write' },
+    complete_task: { mutatesState: true, resourceType: 'todoist_task', executionMode: 'ordered_write' },
+    delete_todoist_task: { mutatesState: true, resourceType: 'todoist_task', executionMode: 'ordered_write' },
+    get_completed_todoist_tasks: { mutatesState: false, resourceType: 'todoist_task', executionMode: 'parallel_read' },
   };
 
   constructor() {
@@ -66,25 +30,22 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
 
     this.todoistService = new TodoistAPIService(todoistApiKey);
 
-    logger.info('DirectToolCallDispatcher initialized', {
+    getLogger({ requestId: 'startup', component: 'tool_dispatcher' }).info('tool.dispatcher.initialized', {
       hasTodoistService: !!this.todoistService,
     });
   }
 
-  /**
-   * Executes multiple tool calls in parallel and returns results
-   *
-   * @param toolCalls - Array of function calls from GPT
-   * @param userId - User ID for context/authorization
-   * @returns Promise<ToolResult[]> - Results of all tool executions
-   */
-  async executeToolCalls(
-    toolCalls: ToolCall[],
-    context: ToolExecutionContext,
-  ): Promise<ToolResult[]> {
-    logger.info('Executing tool calls directly', {
-      jobId: context.jobId,
-      userId: context.userId,
+  async executeToolCalls(toolCalls: ToolCall[], context: ToolExecutionContext): Promise<ToolResult[]> {
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        requestId: context.requestId || context.jobId,
+        component: 'tool_dispatcher',
+        userId: context.userId,
+        chatId: context.chatId,
+        jobId: context.jobId,
+      }),
+    );
+    logger.info('tool.dispatch.started', {
       toolCallsCount: toolCalls.length,
       functionNames: toolCalls.map((tc) => tc.function.name),
     });
@@ -129,23 +90,24 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
     }));
   }
 
-  /**
-   * Executes a single tool call by routing to the appropriate service
-   *
-   * @param toolCall - The function call to execute
-   * @param userId - User ID for context
-   * @returns Promise<any> - The result of the function execution
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async executeToolCall(toolCall: ToolCall, context: ToolExecutionContext): Promise<any> {
+    const logger = getLogger(
+      extendTelemetryContext(context, {
+        requestId: context.requestId || context.jobId,
+        component: 'tool_dispatcher',
+        userId: context.userId,
+        chatId: context.chatId,
+        jobId: context.jobId,
+        stage: 'tool_call',
+      }),
+    );
+    const startTime = Date.now();
+
     try {
       const functionName = toolCall.function.name;
       const parameters = JSON.parse(toolCall.function.arguments);
-      const startTime = Date.now();
 
-      logger.debug('Executing tool call', {
-        jobId: context.jobId,
-        userId: context.userId,
+      logger.info('tool.call.started', {
         functionName,
         toolCallId: toolCall.id,
         parameters: Object.keys(parameters),
@@ -153,40 +115,30 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
 
       const result = await this.routeFunctionCall(functionName, parameters);
 
-      logger.debug('Tool call executed successfully', {
-        jobId: context.jobId,
-        userId: context.userId,
+      logger.info('tool.call.succeeded', {
         functionName,
         toolCallId: toolCall.id,
         hasResult: !!result,
         durationMs: Date.now() - startTime,
       });
+      recordToolCall(functionName, 'success', Date.now() - startTime);
 
       return result;
     } catch (error) {
-      logger.error('Tool call execution error', {
-        jobId: context.jobId,
-        userId: context.userId,
+      logger.error('tool.call.failed', {
         functionName: toolCall.function.name,
         toolCallId: toolCall.id,
-        error: (error as Error).message,
+        ...serializeError(error),
       });
+      recordToolCall(toolCall.function.name, 'error', Date.now() - startTime);
       throw error;
     }
   }
 
-  /**
-   * Routes function calls to appropriate service methods
-   *
-   * @param functionName - Name of the function to call
-   * @param parameters - Function parameters
-   * @returns Promise<any> - Function result
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async routeFunctionCall(functionName: string, parameters: any): Promise<any> {
     switch (functionName) {
       case 'add_todoist_task':
-        return await this.todoistService.addTask({
+        return this.todoistService.addTask({
           content: parameters.content,
           description: parameters.description,
           project_id: parameters.project_id,
@@ -200,12 +152,10 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
           due_datetime: parameters.due_datetime,
           assignee_id: parameters.assignee_id,
         });
-
       case 'get_todoist_task':
-        return await this.todoistService.getTask(parameters.task_id);
-
+        return this.todoistService.getTask(parameters.task_id);
       case 'get_tasks':
-        return await this.todoistService.getTasks({
+        return this.todoistService.getTasks({
           project_id: parameters.project_id,
           section_id: parameters.section_id,
           label: parameters.label,
@@ -213,9 +163,8 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
           lang: parameters.lang,
           ids: parameters.ids,
         });
-
       case 'update_todoist_task':
-        return await this.todoistService.updateTask(parameters.task_id, {
+        return this.todoistService.updateTask(parameters.task_id, {
           content: parameters.content,
           description: parameters.description,
           labels: parameters.labels,
@@ -225,34 +174,25 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
           due_datetime: parameters.due_datetime,
           assignee_id: parameters.assignee_id,
         });
-
       case 'complete_task':
         await this.todoistService.completeTask(parameters.task_id);
         return { success: true, message: `Task ${parameters.task_id} marked as completed` };
-
       case 'delete_todoist_task':
         await this.todoistService.deleteTask(parameters.task_id);
         return { success: true, message: `Task ${parameters.task_id} deleted permanently` };
-
       case 'get_completed_todoist_tasks':
-        return await this.todoistService.getCompletedTasks({
+        return this.todoistService.getCompletedTasks({
           since: parameters.since,
           until: parameters.until,
           project_id: parameters.project_id,
           limit: parameters.limit,
           offset: parameters.offset,
         });
-
       default:
         throw new Error(`Unknown function: ${functionName}`);
     }
   }
 
-  /**
-   * Get list of supported function names
-   *
-   * @returns string[] - Array of supported function names
-   */
   getSupportedFunctions(): string[] {
     return [
       'add_todoist_task',
@@ -265,12 +205,6 @@ export class DirectToolCallDispatcher implements ToolDispatcher {
     ];
   }
 
-  /**
-   * Check if a function is supported
-   *
-   * @param functionName - Function name to check
-   * @returns boolean - True if supported
-   */
   isFunctionSupported(functionName: string): boolean {
     return this.getSupportedFunctions().includes(functionName);
   }

--- a/src/types/gpt.types.ts
+++ b/src/types/gpt.types.ts
@@ -34,6 +34,11 @@ export interface MessageProcessingResult {
   functionCallsCount: number;
   /** Model used for generation */
   model: string;
+  usage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;

--- a/src/types/processing.types.ts
+++ b/src/types/processing.types.ts
@@ -1,7 +1,13 @@
+import { MessageType } from '../observability';
+
 export interface ProcessingContext {
+  requestId?: string;
   jobId?: string;
   sourceMessageId?: string;
   chatId?: string;
+  userId?: string;
+  updateId?: number;
+  messageType?: MessageType;
   onStage?: (eventType: string, message?: string) => Promise<void> | void;
 }
 

--- a/src/types/tool.types.ts
+++ b/src/types/tool.types.ts
@@ -1,3 +1,5 @@
+import { MessageType } from '../observability';
+
 // Interface for OpenAI function calls
 export interface ToolCall {
   id: string;
@@ -25,8 +27,11 @@ export interface ToolExecutionPolicy {
 }
 
 export interface ToolExecutionContext {
+  requestId?: string;
   jobId?: string;
+  chatId?: string;
   userId: string;
+  messageType?: MessageType;
   onStage?: (eventType: string, message?: string) => Promise<void> | void;
 }
 

--- a/src/utils/ai/audioConverter.ts
+++ b/src/utils/ai/audioConverter.ts
@@ -5,7 +5,8 @@ import { spawn } from 'child_process';
 import { writeFile, unlink } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { logger } from '../logger';
+import { TelemetryContext, extendTelemetryContext } from '../../observability';
+import { createComponentLogger, serializeError } from '../logger';
 
 /**
  * Supported input audio formats that can be converted
@@ -93,11 +94,18 @@ export class AudioConverter {
     audioBuffer: Buffer,
     originalExtension: string,
     userId?: number,
+    context?: TelemetryContext,
   ): Promise<ConversionResult> {
     const startTime = Date.now();
+    const logger = createComponentLogger(
+      'audio_converter',
+      extendTelemetryContext(context, {
+        userId: userId ? String(userId) : undefined,
+        stage: 'conversion',
+      }),
+    );
 
-    logger.info('Starting audio conversion', {
-      userId,
+    logger.info('audio.conversion.started', {
       originalFormat: originalExtension,
       targetFormat: TARGET_FORMAT,
       originalSizeBytes: audioBuffer.length,
@@ -126,8 +134,7 @@ export class AudioConverter {
         convertedSizeBytes: convertedBuffer.length,
       };
 
-      logger.info('Audio conversion completed successfully', {
-        userId,
+      logger.info('audio.conversion.succeeded', {
         originalFormat: originalExtension,
         targetFormat: TARGET_FORMAT,
         conversionTimeMs,
@@ -140,12 +147,11 @@ export class AudioConverter {
     } catch (error) {
       const conversionTimeMs = Date.now() - startTime;
 
-      logger.error('Audio conversion failed', {
-        userId,
+      logger.error('audio.conversion.failed', {
         originalFormat: originalExtension,
         targetFormat: TARGET_FORMAT,
-        error: (error as Error).message,
         conversionTimeMs,
+        ...serializeError(error),
       });
 
       // Provide a more helpful error if the installer package is missing.
@@ -275,14 +281,15 @@ export class AudioConverter {
    * @private
    */
   private static async cleanupTempFiles(filePaths: string[]): Promise<void> {
+    const logger = createComponentLogger('audio_converter');
     const cleanupPromises = filePaths.map(async (filePath) => {
       try {
         await unlink(filePath);
       } catch (error) {
         // Ignore cleanup errors, just log them
-        logger.warn('Failed to cleanup temporary file', {
+        logger.warn('audio.conversion.cleanup_failed', {
           filePath,
-          error: (error as Error).message,
+          ...serializeError(error),
         });
       }
     });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,12 +1,115 @@
-// services/utils/logger.ts
 import winston from 'winston';
+import { TelemetryContext, LogFields } from '../observability/types';
 
-export const logger = winston.createLogger({
-  level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+const REDACTED = '[REDACTED]';
+const TELEGRAM_FILE_URL_PATTERN = /https:\/\/api\.telegram\.org\/file\/bot[^\s"]+/g;
+const ENV_SECRET_KEYS = ['BOT_TOKEN', 'TELEGRAM_SECRET_TOKEN', 'OPENAI_API_KEY', 'TODOIST_API_KEY'];
+
+function getLogLevel(): string {
+  if (process.env.LOG_LEVEL) {
+    return process.env.LOG_LEVEL;
+  }
+
+  return process.env.NODE_ENV === 'production' ? 'info' : 'debug';
+}
+
+function sanitizeString(value: string): string {
+  let sanitized = value.replace(TELEGRAM_FILE_URL_PATTERN, REDACTED);
+
+  for (const envKey of ENV_SECRET_KEYS) {
+    const secret = process.env[envKey];
+    if (secret) {
+      sanitized = sanitized.split(secret).join(REDACTED);
+    }
+  }
+
+  return sanitized;
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (value instanceof Error) {
+    return serializeError(value);
+  }
+
+  if (typeof value === 'string') {
+    return sanitizeString(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => [
+        key,
+        sanitizeValue(nestedValue),
+      ]),
+    );
+  }
+
+  return value;
+}
+
+const sanitizeFormat = winston.format((info) => sanitizeValue(info) as winston.Logform.TransformableInfo);
+
+const baseLogger = winston.createLogger({
+  level: getLogLevel(),
+  defaultMeta: {
+    service: process.env.SERVICE_NAME || 'jarvis-mcp',
+    env: process.env.NODE_ENV || 'development',
+    version: process.env.SERVICE_VERSION || process.env.npm_package_version || 'unknown',
+  },
   format: winston.format.combine(
     winston.format.timestamp(),
-    winston.format.errors({ stack: true }), // logs stack trace
+    winston.format.errors({ stack: true }),
+    sanitizeFormat(),
     winston.format.json(),
   ),
   transports: [new winston.transports.Console()],
 });
+
+export const logger = baseLogger;
+
+export function serializeError(error: unknown): LogFields {
+  if (!(error instanceof Error)) {
+    return {
+      errorMessage: typeof error === 'string' ? sanitizeString(error) : 'Unknown error',
+    };
+  }
+
+  const normalized = error as Error & { code?: string };
+  return {
+    errorName: normalized.name,
+    errorMessage: sanitizeString(normalized.message),
+    errorStack: normalized.stack ? sanitizeString(normalized.stack) : undefined,
+    errorCode: normalized.code,
+  };
+}
+
+export function getLogger(context?: TelemetryContext): winston.Logger {
+  if (!context) {
+    return baseLogger;
+  }
+
+  return baseLogger.child(
+    Object.fromEntries(
+      Object.entries(context).filter(([, value]) => value !== undefined),
+    ) as TelemetryContext,
+  );
+}
+
+export function createComponentLogger(
+  component: string,
+  context?: TelemetryContext,
+): winston.Logger {
+  if (!context) {
+    return baseLogger.child({ component });
+  }
+
+  return getLogger(context).child({ component });
+}
+
+export function sanitizeForLogging(value: unknown): unknown {
+  return sanitizeValue(value);
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,8 +1,27 @@
+type MockLogger = {
+  info: jest.Mock;
+  warn: jest.Mock;
+  error: jest.Mock;
+  debug: jest.Mock;
+  child: jest.Mock;
+};
+
+const mockedLogger: MockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn(),
+};
+
+mockedLogger.child.mockImplementation(() => mockedLogger);
+
 jest.mock('../src/utils/logger', () => ({
-  logger: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    debug: jest.fn(),
-  },
+  logger: mockedLogger,
+  getLogger: jest.fn(() => mockedLogger),
+  createComponentLogger: jest.fn(() => mockedLogger),
+  serializeError: jest.fn((error: unknown) => ({
+    errorMessage: error instanceof Error ? error.message : String(error),
+  })),
+  sanitizeForLogging: jest.fn((value: unknown) => value),
 }));

--- a/tests/unit/controllers/webhook.controller.test.ts
+++ b/tests/unit/controllers/webhook.controller.test.ts
@@ -66,7 +66,13 @@ describe('createWebhookRouter', () => {
     );
 
     expect(response.sendStatus).toHaveBeenCalledWith(200);
-    expect(handleUpdate).toHaveBeenCalledWith(update);
+    expect(handleUpdate).toHaveBeenCalledWith(
+      update,
+      expect.objectContaining({
+        component: 'webhook',
+        updateId: 42,
+      }),
+    );
   });
 
   it('returns 500 when bot update handling fails', async () => {

--- a/tests/unit/observability/logger.test.ts
+++ b/tests/unit/observability/logger.test.ts
@@ -1,0 +1,30 @@
+describe('logger utilities', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('redacts secrets and telegram file urls from log payloads', () => {
+    process.env.OPENAI_API_KEY = 'openai-secret';
+    process.env.BOT_TOKEN = 'bot-secret';
+
+    const { sanitizeForLogging, serializeError } = jest.requireActual('../../../src/utils/logger');
+
+    expect(
+      sanitizeForLogging({
+        apiKey: 'openai-secret',
+        fileUrl: 'https://api.telegram.org/file/botbot-secret/private/file.ogg',
+      }),
+    ).toEqual({
+      apiKey: '[REDACTED]',
+      fileUrl: '[REDACTED]',
+    });
+
+    expect(serializeError(new Error('boom openai-secret'))).toEqual(
+      expect.objectContaining({
+        errorMessage: 'boom [REDACTED]',
+      }),
+    );
+  });
+});

--- a/tests/unit/observability/metrics.test.ts
+++ b/tests/unit/observability/metrics.test.ts
@@ -1,0 +1,32 @@
+import {
+  getMetricsContentType,
+  getMetricsSnapshot,
+  recordOpenAIRequest,
+  recordWebhook,
+  resetMetrics,
+} from '../../../src/observability';
+
+describe('observability metrics', () => {
+  beforeEach(() => {
+    resetMetrics();
+  });
+
+  it('renders prometheus metrics text for recorded counters and histograms', async () => {
+    recordWebhook('success', 42);
+    recordOpenAIRequest(
+      { model: 'gpt-4o', operation: 'simple_text', status: 'success' },
+      120,
+      { promptTokens: 10, completionTokens: 4, totalTokens: 14 },
+    );
+
+    const output = await getMetricsSnapshot();
+
+    expect(getMetricsContentType()).toContain('text/plain');
+    expect(output).toContain('jarvis_webhook_requests_total{status="success"} 1');
+    expect(output).toContain(
+      'jarvis_openai_requests_total{model="gpt-4o",operation="simple_text",status="success"} 1',
+    );
+    expect(output).toContain('jarvis_openai_tokens_total{direction="total",model="gpt-4o"} 14');
+    expect(output).toContain('jarvis_webhook_duration_ms_bucket');
+  });
+});


### PR DESCRIPTION
## Summary
Merge the structured observability work onto current `main` after reviewing and reconciling it with the async job queue and persistence changes.

## Why
The original logging branch was based on an older application shape. Current `main` now has async intake, job workers, persistence, and queueing, so the observability work needed a careful merge instead of a direct landing.

## Changes made
- carry over the structured logging, telemetry context, metrics export, and redaction work onto the current async architecture
- instrument webhook ingress, Telegram update handling, GPT/Whisper processing, and tool dispatch while preserving current job queue behavior
- keep duplicate-update detection, usage tracking, and conversation persistence wiring from `main`
- add observability docs and unit coverage for logger redaction and metrics export

## Testing
- `npm install`
- `npm run build`
- `npm test -- --runInBand`

## Notes
- this branch is a reviewed merge of the logging work onto the current `main` codebase, not a blind cherry-pick
- the original local `main` worktree was dirty, so the merge was completed in a clean integration worktree and published from there
